### PR TITLE
Produce a backwards-compatible Java 9 module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <dyn4j.maven-javadoc-plugin.version>3.0.0-M1</dyn4j.maven-javadoc-plugin.version>
     <dyn4j.nexus-staging-maven-plugin.version>1.6.8</dyn4j.nexus-staging-maven-plugin.version>
     <dyn4j.maven-gpg-plugin.version>1.6</dyn4j.maven-gpg-plugin.version>
+    <dyn4.maven-enforcer-plugin.version>3.0.0-M1</dyn4.maven-enforcer-plugin.version>
   </properties>
 
   <organization>
@@ -106,6 +107,17 @@
         </plugin>
 
         <!--
+          Enforcer plugin.
+          https://maven.apache.org/enforcer/maven-enforcer-plugin/
+        -->
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${dyn4.maven-enforcer-plugin.version}</version>
+        </plugin>
+
+        <!--
         Maven Compiler plugin.
         https://maven.apache.org/plugins/maven-compiler-plugin/
         -->
@@ -114,10 +126,42 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${dyn4j.maven-compiler-plugin.version}</version>
+          <executions>
+
+            <!--
+              Compile everything as JDK 9 bytecode: This ensures that we get
+              decent compilation errors such as missing "requires" directives
+              in the module descriptor.
+            -->
+
+            <execution>
+              <id>default-compile</id>
+              <configuration>
+                <release>9</release>
+              </configuration>
+            </execution>
+
+            <!--
+              Recompile everything except for the module descriptor as JDK 6
+              bytecode.
+            -->
+
+            <execution>
+              <id>compile-6</id>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+              <configuration>
+                <excludes>
+                  <exclude>module-info.java</exclude>
+                </excludes>
+              </configuration>
+            </execution>
+          </executions>
+
+          <!-- These are the default settings for all executions. -->
           <configuration>
-            <!-- Require JDK >= 1.6 -->
-            <source>1.6</source>
-            <target>1.6</target>
+            <release>6</release>
           </configuration>
         </plugin>
 
@@ -202,6 +246,16 @@
               <Bundle-DocURL>${project.url}</Bundle-DocURL>
             </instructions>
           </configuration>
+
+          <!-- Use a newer version of bndlib that supports Java 9    -->
+          <!-- See: https://issues.apache.org/jira/browse/FELIX-5698 -->
+          <dependencies>
+            <dependency>
+              <groupId>biz.aQute.bnd</groupId>
+              <artifactId>biz.aQute.bndlib</artifactId>
+              <version>3.5.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!--
@@ -257,6 +311,29 @@
     </pluginManagement>
 
     <plugins>
+
+      <!-- Check various preconditions for building. -->
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+          <id>enforce-rules</id>
+          <phase>validate</phase>
+          <goals>
+            <goal>enforce</goal>
+          </goals>
+          <configuration>
+            <rules>
+              <!-- Require JDK 9+ -->
+              <requireJavaVersion>
+                <version>[9,)</version>
+              </requireJavaVersion>
+            </rules>
+          </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Produce a source jar -->
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2017 William Bittle  http://www.dyn4j.org/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this list of conditions
+ *     and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *     and the following disclaimer in the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of dyn4j nor the names of its contributors may be used to endorse or
+ *     promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+module org.dyn4j
+{
+  exports org.dyn4j.collision.broadphase;
+  exports org.dyn4j.collision.continuous;
+  exports org.dyn4j.collision.manifold;
+  exports org.dyn4j.collision.narrowphase;
+  exports org.dyn4j.collision;
+  exports org.dyn4j.dynamics.contact;
+  exports org.dyn4j.dynamics.joint;
+  exports org.dyn4j.dynamics;
+  exports org.dyn4j.geometry.decompose;
+  exports org.dyn4j.geometry.hull;
+  exports org.dyn4j.geometry;
+  exports org.dyn4j;
+}


### PR DESCRIPTION
This adds the necessary definitions to produce a jar file that will
behave as a real module on Java 9, but will also execute correctly
on Java 6 and above.

This adds a maven-enforcer-plugin rule to require JDK 9 to build
the code (and to give a friendly error message if the user attempts
to build on a JDK older than 9). It adds two compiler executions:
One that compiles all of the code as Java 9 bytecode in order to
get accurate error messages with regards to module problems (such
as missing "requires" directives, using APIs that are not in Java 6,
etc), and another execution to recompile all of the code except for
the module descriptor as JDK 6 bytecode.

It also adds a temporary dependency on Bnd 3.5.0 in order to work
around FELIX-5698.

See: https://issues.apache.org/jira/browse/FELIX-5698
Affects: #29