### PR TITLE
Shape optimizations (and a new shape class)

### DIFF
--- a/src/main/java/org/dyn4j/geometry/Ellipse.java
+++ b/src/main/java/org/dyn4j/geometry/Ellipse.java
@@ -53,20 +53,14 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 	/** The desired accuracy for the farthest point */
 	private static final double FARTHEST_POINT_EPSILON = 1.0e-8;
 	
-	/** The ellipse width */
-	final double width;
-	
-	/** The ellipse height */
-	final double height;
-	
 	/** The half-width */
 	final double halfWidth;
 	
 	/** The half-height */
 	final double halfHeight;
 	
-	/** A local vector to  */
-	final Vector2 localXAxis;
+	/** The local rotation in radians */
+	double rotation;
 	
 	/**
 	 * Validated constructor.
@@ -80,17 +74,13 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 	private Ellipse(boolean valid, double width, double height) {
 		super(Math.max(width, height) * 0.5);
 		
-		this.width = width;
-		this.height = height;
-		
 		// compute the major and minor axis lengths
 		// (the x,y radii)
 		this.halfWidth = width * 0.5;
 		this.halfHeight = height * 0.5;
 		
-		// since we create ellipses as axis aligned we set the local x axis
-		// to the world space x axis
-		this.localXAxis = new Vector2(1.0, 0.0);
+		// initial rotation 0 means the ellipse is aligned to the world space x axis
+		this.rotation = 0;
 	}
 	
 	/**
@@ -128,8 +118,8 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("Ellipse[").append(super.toString())
-		.append("|Width=").append(this.width)
-		.append("|Height=").append(this.height)
+		.append("|Width=").append(this.getWidth())
+		.append("|Height=").append(this.getHeight())
 		.append("]");
 		return sb.toString();
 	}
@@ -220,10 +210,29 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 	 */
 	@Override
 	public AABB createAABB(Transform transform) {
+		/*
+		Below is an inlined optimized version of this:
+		
 		Interval x = this.project(Vector2.X_AXIS, transform);
 		Interval y = this.project(Vector2.Y_AXIS, transform);
-		
 		return new AABB(x.getMin(), y.getMin(), x.getMax(), y.getMax());
+		
+		Because the vectors are the x and y axis we can perform various meaningful optimizations
+		*/
+		
+		//inlined projection of x axis
+		Vector2 p1 = this.getFarthestPoint(Vector2.X_AXIS, transform);
+		double c = transform.getTransformedX(this.center);
+		double minx = 2 * c - p1.x;
+		double maxx = p1.x;
+		
+		//inlined projection of y axis
+		p1 = this.getFarthestPoint(Vector2.Y_AXIS, transform);
+		c = transform.getTransformedY(this.center);
+		double miny = 2 * c - p1.y;
+		double maxy = p1.y;
+		
+		return new AABB(minx, miny, maxx, maxy);
 	}
 	
 	/* (non-Javadoc)
@@ -461,7 +470,7 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 	public void rotate(double theta, double x, double y) {
 		super.rotate(theta, x, y);
 		// rotate the local axis as well
-		this.localXAxis.rotate(theta);
+		this.rotation += theta;
 	}
 	
 	/**
@@ -469,7 +478,7 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 	 * @return double the rotation in radians
 	 */
 	public double getRotation() {
-		return Vector2.X_AXIS.getAngleBetween(this.localXAxis);
+		return rotation;
 	}
 	
 	/**
@@ -477,7 +486,7 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 	 * @return double
 	 */
 	public double getWidth() {
-		return this.width;
+		return this.halfWidth * 2;
 	}
 	
 	/**
@@ -485,7 +494,7 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 	 * @return double
 	 */
 	public double getHeight() {
-		return this.height;
+		return this.halfHeight * 2;
 	}
 	
 	/**

--- a/src/main/java/org/dyn4j/geometry/HalfEllipse.java
+++ b/src/main/java/org/dyn4j/geometry/HalfEllipse.java
@@ -50,24 +50,21 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	 */
 	private static final double INERTIA_CONSTANT = Math.PI / 8.0 - 8.0 / (9.0 * Math.PI);
 	
-	/** The ellipse width */
-	final double width;
-	
 	/** The ellipse height */
 	final double height;
 	
 	/** The half-width */
 	final double halfWidth;
 	
-	/** A local vector to  */
-	public final Vector2 localXAxis;
-
+	/** The local rotation in radians */
+	double rotation;
+	
 	/** The ellipse center */
 	final Vector2 ellipseCenter;
 	
 	/** The vertices of the bottom */
-	final Vector2[] vertices;
-
+	final Vector2 verticeLeft, verticeRight;
+	
 	/**
 	 * Validated constructor.
 	 * <p>
@@ -78,11 +75,10 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	 * @param center the center
 	 * @param vertices the vertices
 	 */
-	private HalfEllipse(boolean valid, double width, double height, Vector2 center, Vector2[] vertices) {
-		super(center, center.distance(vertices[1]));
+	private HalfEllipse(boolean valid, double width, double height, Vector2 center, Vector2 verticeLeft, Vector2 verticeRight) {
+		super(center, center.distance(verticeRight));
 		
-		// set width and height
-		this.width = width;
+		// set height. width can be computed as halfWidth * 2 when needed
 		this.height = height;
 		
 		// compute the major and minor axis lengths
@@ -92,12 +88,12 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 		// set the ellipse center
 		this.ellipseCenter = new Vector2();
 		
-		// since we create ellipses as axis aligned we set the local x axis
-		// to the world space x axis
-		this.localXAxis = new Vector2(1.0, 0.0);
+		// initial rotation 0 means the half ellipse is aligned to the world space x axis
+		this.rotation = 0;
 		
 		// setup the vertices
-		this.vertices = vertices;
+		this.verticeLeft = verticeLeft;
+		this.verticeRight = verticeRight;
 	}
 	
 	/**
@@ -115,12 +111,11 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 			width, 
 			height, 
 			new Vector2(0, (4.0 * height) / (3.0 * Math.PI)), 
-			new Vector2[] {
-				// the left point
-				new Vector2(-width * 0.5, 0),
-				// the right point
-				new Vector2( width * 0.5, 0)
-			 });
+			// the left point
+			new Vector2(-width * 0.5, 0),
+			// the right point
+			new Vector2( width * 0.5, 0)
+			);
 	}
 	
 	/**
@@ -145,8 +140,8 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("HalfEllipse[").append(super.toString())
-		.append("|Width=").append(this.width)
-		.append("|Height=").append(this.height)
+		.append("|Width=").append(this.getWidth())
+		.append("|Height=").append(this.getHeight())
 		.append("]");
 		return sb.toString();
 	}
@@ -196,9 +191,9 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 		
 		Vector2 p = null;
 		if (localAxis.y <= 0 && localAxis.x >= 0) {
-			return transform.getTransformed(this.vertices[1]);
+			return transform.getTransformed(this.verticeRight);
 		} else if (localAxis.y <= 0 && localAxis.x <= 0) {
-			return transform.getTransformed(this.vertices[0]);
+			return transform.getTransformed(this.verticeLeft);
 		} else {
 			// add the radius along the vector to the center to get the farthest point
 			p = new Vector2(localAxis.x * this.halfWidth, localAxis.y  * this.height);
@@ -219,13 +214,14 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	@Override
 	public Feature getFarthestFeature(Vector2 vector, Transform transform) {
 		Vector2 localAxis = transform.getInverseTransformedR(vector);
-		if (localAxis.getAngleBetween(this.localXAxis) < 0) {
+		
+		if (localAxis.getAngleBetween(rotation) < 0) {
 			// then its the farthest point
 			Vector2 point = this.getFarthestPoint(vector, transform);
 			return new PointFeature(point);
 		} else {
 			// return the full bottom side
-			return Segment.getFarthestFeature(this.vertices[0], this.vertices[1], vector, transform);
+			return Segment.getFarthestFeature(this.verticeLeft, this.verticeRight, vector, transform);
 		}
 	}
 	
@@ -282,8 +278,14 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 		// in the half ellipse case, if the point is on the side of the flat edge
 		// then we do the ellipse code, else we can just return the farthest of the
 		// two points that make up the flat side
-		if (Segment.getLocation(center, this.vertices[0], this.vertices[1]) > 0) {
-			return Geometry.getRotationRadius(center, vertices);
+		if (Segment.getLocation(center, this.verticeLeft, this.verticeRight) > 0) {
+			// find the maximum radius from the center
+			double leftR = center.distanceSquared(this.verticeLeft);
+			double rightR = center.distanceSquared(this.verticeRight);
+			// keep the largest
+			double r2 = Math.max(leftR, rightR);
+			
+			return Math.sqrt(r2);
 		} else {		
 			// we need to translate/rotate the point so that this ellipse is
 			// considered centered at the origin with it's semi-major axis aligned
@@ -343,11 +345,10 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	public void rotate(double theta, double x, double y) {
 		super.rotate(theta, x, y);
 		// rotate the local axis as well
-		this.localXAxis.rotate(theta);
+		this.rotation += theta;
 		// rotate the vertices
-		for (int i = 0; i < this.vertices.length; i++) {
-			this.vertices[i].rotate(theta, x, y);
-		}
+		this.verticeLeft.rotate(theta, x, y);
+		this.verticeRight.rotate(theta, x, y);
 		// rotate the ellipse center
 		this.ellipseCenter.rotate(theta, x, y);
 	}
@@ -360,9 +361,8 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 		// translate the centroid
 		super.translate(x, y);
 		// translate the pie vertices
-		for (int i = 0; i < this.vertices.length; i++) {
-			this.vertices[i].add(x, y);
-		}
+		this.verticeLeft.add(x, y);
+		this.verticeRight.add(x, y);
 		// translate the ellipse center
 		this.ellipseCenter.add(x, y);
 	}
@@ -372,7 +372,7 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	 * @return double the rotation in radians
 	 */
 	public double getRotation() {
-		return Vector2.X_AXIS.getAngleBetween(this.localXAxis);
+		return rotation;
 	}
 	
 	/**
@@ -380,7 +380,7 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	 * @return double
 	 */
 	public double getWidth() {
-		return this.width;
+		return this.halfWidth * 2;
 	}
 	
 	/**

--- a/src/main/java/org/dyn4j/geometry/Polygon.java
+++ b/src/main/java/org/dyn4j/geometry/Polygon.java
@@ -306,7 +306,7 @@ public class Polygon extends AbstractShape implements Convex, Wound, Shape, Tran
 		}
 		return true;
 	}
-
+	
 	/* (non-Javadoc)
 	 * @see org.dyn4j.geometry.AbstractShape#rotate(double, double, double)
 	 */
@@ -366,20 +366,18 @@ public class Polygon extends AbstractShape implements Convex, Wound, Shape, Tran
 	public EdgeFeature getFarthestFeature(Vector2 vector, Transform transform) {
 		// transform the normal into local space
 		Vector2 localn = transform.getInverseTransformedR(vector);
-		Vector2 maximum = new Vector2();
-		double max = -Double.MAX_VALUE;
+		
+		double max = localn.dot(this.vertices[0]);
 		int index = 0;
 		// find the vertex on the polygon that is further along on the penetration axis
 		int count = this.vertices.length;
-		for (int i = 0; i < count; i++) {
+		for (int i = 1; i < count; i++) {
 			// get the current vertex
 			Vector2 v = this.vertices[i];
 			// get the scalar projection of v onto axis
 			double projection = localn.dot(v);
 			// keep the maximum projection point
 			if (projection > max) {
-				// set the max point
-				maximum.set(v);
 				// set the new maximum
 				max = projection;
 				// save the index
@@ -387,10 +385,10 @@ public class Polygon extends AbstractShape implements Convex, Wound, Shape, Tran
 			}
 		}
 		
+		Vector2 maximum = new Vector2(this.vertices[index]);
+		
 		// once we have the point of maximum
 		// see which edge is most perpendicular
-		int l = index + 1 == count ? 0 : index + 1;
-		int r = index - 1 < 0 ? count - 1 : index - 1;
 		Vector2 leftN = this.normals[index == 0 ? count - 1 : index - 1];
 		Vector2 rightN = this.normals[index];
 		// create the maximum point for the feature (transform the maximum into world space)
@@ -398,11 +396,15 @@ public class Polygon extends AbstractShape implements Convex, Wound, Shape, Tran
 		PointFeature vm = new PointFeature(maximum, index);
 		// is the left or right edge more perpendicular?
 		if (leftN.dot(localn) < rightN.dot(localn)) {
+			int l = index + 1 == count ? 0 : index + 1;
+			
 			Vector2 left = transform.getTransformed(this.vertices[l]);
 			PointFeature vl = new PointFeature(left, l);
 			// make sure the edge is the right winding
 			return new EdgeFeature(vm, vl, vm, maximum.to(left), index + 1);
 		} else {
+			int r = index - 1 < 0 ? count - 1 : index - 1;
+			
 			Vector2 right = transform.getTransformed(this.vertices[r]);
 			PointFeature vr = new PointFeature(right, r);
 			// make sure the edge is the right winding
@@ -417,9 +419,9 @@ public class Polygon extends AbstractShape implements Convex, Wound, Shape, Tran
 	public Vector2 getFarthestPoint(Vector2 vector, Transform transform) {
 		// transform the normal into local space
 		Vector2 localn = transform.getInverseTransformedR(vector);
-		Vector2 point = new Vector2();
+		
 		// set the farthest point to the first one
-		point.set(this.vertices[0]);
+		int index = 0;
 		// prime the projection amount
 		double max = localn.dot(this.vertices[0]);
 		// loop through the rest of the vertices to find a further point along the axis
@@ -432,14 +434,16 @@ public class Polygon extends AbstractShape implements Convex, Wound, Shape, Tran
 			// check to see if the projection is greater than the last
 			if (projection > max) {
 				// otherwise this point is the farthest so far so clear the array and add it
-				point.set(v);
+				index = i;
 				// set the new maximum
 				max = projection;
 			}
 		}
-		// transform the point into world space
-		transform.transform(point);
-		return point;
+		
+		Vector2 point = new Vector2(this.vertices[index]);
+		
+		// transform the point into world space and return
+		return transform.getTransformed(point);
 	}
 	
 	/**
@@ -519,6 +523,7 @@ public class Polygon extends AbstractShape implements Convex, Wound, Shape, Tran
 		// (center is the vector from the average center to the area weighted center since
 		// the average center is used as the origin)
 		I -= m * center.getMagnitudeSquared();
+		
 		return new Mass(c, m, I);
 	}
 	
@@ -527,23 +532,21 @@ public class Polygon extends AbstractShape implements Convex, Wound, Shape, Tran
 	 */
 	@Override
 	public AABB createAABB(Transform transform) {
-		double vx = 0.0;
-		double vy = 0.0;
-    	// get the first point
+		// get the first point
 		Vector2 p = transform.getTransformed(this.vertices[0]);
 		// project the point onto the vector
-    	double minX = Vector2.X_AXIS.dot(p);
-    	double maxX = minX;
-    	double minY = Vector2.Y_AXIS.dot(p);
-    	double maxY = minY;
+    	double minX = p.x;
+    	double maxX = p.x;
+    	double minY = p.y;
+    	double maxY = p.y;
     	// loop over the rest of the vertices
     	int size = this.vertices.length;
         for(int i = 1; i < size; i++) {
     		// get the next point
     		p = transform.getTransformed(this.vertices[i]);
     		// project it onto the vector
-            vx = Vector2.X_AXIS.dot(p);
-            vy = Vector2.Y_AXIS.dot(p);
+            double vx = p.x;
+            double vy = p.y;
             // compare the x values
             if (vx < minX) {
             	minX = vx;

--- a/src/main/java/org/dyn4j/geometry/Rectangle.java
+++ b/src/main/java/org/dyn4j/geometry/Rectangle.java
@@ -263,4 +263,35 @@ public class Rectangle extends Polygon implements Convex, Wound, Shape, Transfor
 		// for the centroid
 		return new Mass(this.center, mass, inertia);
 	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.geometry.Shape#createAABB(org.dyn4j.geometry.Transform)
+	 */
+	@Override
+	public AABB createAABB(Transform transform) {
+		//Specialization of Polygon.createAABB
+		//Since we know that this is a rectangle we can get away with much fewer
+		//comparisons to find the correct AABB. Each vertex maps to one point of the
+		//AABB, we have to find in which of the four possible rotation states this
+		//rectangle currently is. This is done below by comparing the first two vertices
+		
+		Vector2 v0 = transform.getTransformed(this.vertices[0]);
+		Vector2 v1 = transform.getTransformed(this.vertices[1]);
+		Vector2 v2 = transform.getTransformed(this.vertices[2]);
+		Vector2 v3 = transform.getTransformed(this.vertices[3]);
+		
+		if (v0.y > v1.y) {
+			if (v0.x < v1.x) {
+				return new AABB(v0.x, v1.y, v2.x, v3.y);
+			} else {
+				return new AABB(v1.x, v2.y, v3.x, v0.y);
+			}
+		} else {
+			if (v0.x < v1.x) {
+				return new AABB(v3.x, v0.y, v1.x, v2.y);
+			} else {
+				return new AABB(v2.x, v3.y, v0.x, v1.y);
+			}
+		}
+	}
 }

--- a/src/main/java/org/dyn4j/geometry/RegularPolygon.java
+++ b/src/main/java/org/dyn4j/geometry/RegularPolygon.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2010-2016 William Bittle  http://www.dyn4j.org/
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted 
+ * provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice, this list of conditions 
+ *     and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions 
+ *     and the following disclaimer in the documentation and/or other materials provided with the 
+ *     distribution.
+ *   * Neither the name of dyn4j nor the names of its contributors may be used to endorse or 
+ *     promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER 
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.dyn4j.geometry;
+
+import org.dyn4j.DataContainer;
+import org.dyn4j.resources.Messages;
+
+/**
+ * Implementation of a regular polygon {@link Convex} {@link Shape}.
+ * Regular polygons can already be constructed with the Geometry class but we can exploit the 
+ * properties of regular polygons to create a more efficient implementation.
+ * <p>
+ * The big difference with the existing polygon class is that for a regular polygon with N vertices
+ * the methods getFarthestFeature, getFarthestPoint and createAABB can be implemented (as shown below)
+ * in O(1) time instead of the existing O(N) of the polygon class.
+ * We also have a much easier and faster way of calculating the mass.
+ * The benefit is apparent with regular polygons with many vertices.
+ * Also there is no need to store the normals array, saving half the memory.
+ * (At the moment this comes at the cost of not having getAxes implemented)
+ * <p>
+ * It should be noted that for small polygons this will probably perform slightly worse.
+ * <p>
+ * A {@link RegularPolygon} must have at least 3 vertices.
+ * @author Manolis Tsamis
+ * @version 3.3.0
+ * @since 3.3.0
+ */
+public class RegularPolygon extends Polygon implements Convex, Wound, Shape, Transformable, DataContainer {
+	
+	/** The number of vertices this regular has */
+	protected final int count;
+
+	/** The inverse of the angular increment */
+	protected final double invAngle;
+	
+	/** Rotation needed for computations (in radians)
+	 *  Note that this is used in a strange way to cancel out the rotation
+	 *  from the rotate(...) methods. Also contains an initial rotation constant (see constructor)*/
+	protected double rotation;
+	
+	/**
+	 * Validated constructor.
+	 * <p>
+	 * Creates a new {@link RegularPolygon} with the given vertice count and angle.
+	 * @param count the number of vertices for this regular polygon
+	 * @param radius the radius of the circle in which this polygon is insribed
+	 */
+	private RegularPolygon(boolean valid, int count, double radius) {
+		super(new Vector2(), radius, createRegularPolygonVertices(count, radius), null);
+		
+		// This is the needed inital offset so that this polygon is aligned
+		// the same as the existing polygon creation of the Geometry class
+		// See getFarthestPoint
+		this.rotation = Geometry.TWO_PI + (Geometry.TWO_PI / count) / 2;
+		
+		this.count = count;
+		this.invAngle = count / Geometry.TWO_PI;
+	}
+	
+	private static Vector2[] createRegularPolygonVertices(int count, double radius) {
+		// NOTE: taken from Geometry.createPolygonalCircle
+		// compute the angular increment
+		final double pin = Geometry.TWO_PI / count;
+		// make sure the resulting output is an even number of vertices
+		final Vector2[] vertices = new Vector2[count];
+
+		final double c = Math.cos(pin);
+		final double s = Math.sin(pin);
+		
+		double x = radius;
+		double y = 0;
+		
+		for(int i = 0; i < count; i++) {
+			vertices[i] = new Vector2(x, y);
+
+			//apply the rotation matrix
+			double t = x;
+			x = c * t - s * y;
+			y = s * t + c * y;
+		}
+		
+		return vertices;
+	}
+	
+	/**
+	 * Full constructor.
+	 * <p>
+	 * Creates a new {@link RegularPolygon} with the given vertice count and angle.
+	 * @param count the number of vertices for this regular polygon
+	 * @param radius the radius of the circle in which this polygon is insribed
+	 */
+	public RegularPolygon(int count, double radius) {
+		this(validate(count, radius), count, radius);
+	}
+	
+	/**
+	 * Validates the constructor input returning true if valid or throwing an exception if invalid.
+	 * @param count the number of vertices
+	 * @param radius the radius of the regular polygon to be made
+	 * @return boolean true
+	 * @throws IllegalArgumentException if radius is less than or equal to zero or count is less than 3
+	 */
+	private static final boolean validate(int count, double radius) {
+		if (count < 3) throw new IllegalArgumentException(Messages.getString("geometry.circleInvalidCount"));
+		if (radius <= 0.0) throw new IllegalArgumentException(Messages.getString("geometry.circleInvalidRadius"));
+		
+		return true;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.geometry.Wound#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("RegularPolygon[").append(super.toString())
+			.append("|Count=").append(count)
+			.append("|Radius=").append(radius)
+			.append("|Vertices={");
+		for (int i = 0; i < this.vertices.length; i++) {  
+			if (i != 0) sb.append(",");
+			sb.append(this.vertices[i]);
+		}
+		sb.append("}")
+		  .append("]");
+		return sb.toString();
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.geometry.AbstractShape#rotate(double, double, double)
+	 */
+	@Override
+	public void rotate(double theta, double x, double y) {
+		// NOTE: copied from Polygon.rotate and AbstractShape.rotate
+		// only rotate the center if the point about which
+		// we are rotating is not the center
+		if (!this.center.equals(x, y)) {
+			this.center.rotate(theta, x, y);
+		}
+		
+		// omit the normals
+		int size = this.vertices.length;
+		for (int i = 0; i < size; i++) {
+			this.vertices[i].rotate(theta, x, y);
+		}
+		
+		//cancel out the rotation for computations
+		rotation -= theta;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.geometry.Convex#getFarthestFeature(org.dyn4j.geometry.Vector2, org.dyn4j.geometry.Transform)
+	 */
+	@Override
+	public EdgeFeature getFarthestFeature(Vector2 vector, Transform transform) {
+		// transform the normal into local space
+		Vector2 localn = transform.getInverseTransformedR(vector);
+		
+		// See explanation in getFarthestPoint
+		double rot = Math.atan2(localn.y, localn.x) + rotation;
+		double select = rot * invAngle;
+		int fmax = (int) (select);
+		// this serves to find on which side this point lies
+		// if fmax == fother then the edge needed is the left of the max
+		// else if fmax < fother the right one is needed (fmax == fother - 1)
+		int fother = (int) (select + 0.5);
+		int maxIndex = fmax % count;
+		
+		Vector2 maximum = transform.getTransformed(this.vertices[maxIndex]);
+		PointFeature vm = new PointFeature(maximum, maxIndex);
+		
+		if (fmax < fother) {
+			int index1 = (fother) % count;
+			Vector2 right = transform.getTransformed(this.vertices[index1]);
+			PointFeature vr = new PointFeature(right, index1);
+			
+			// make sure the edge is the right winding
+			return new EdgeFeature(vm, vr, vm, maximum.to(right), maxIndex + 1);
+		} else {
+			int index1 = (fmax - 1) % count;
+			Vector2 left = transform.getTransformed(this.vertices[index1]);
+			PointFeature vl = new PointFeature(left, index1);
+			
+			// make sure the edge is the right winding
+			return new EdgeFeature(vl, vm, vm, left.to(maximum), maxIndex);
+		}
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.geometry.Convex#getFarthestPoint(org.dyn4j.geometry.Vector2, org.dyn4j.geometry.Transform)
+	 */
+	@Override
+	public Vector2 getFarthestPoint(Vector2 vector, Transform transform) {
+		// transform the normal into local space
+		Vector2 localn = transform.getInverseTransformedR(vector);
+		
+		// We will be choosing one of the vertices based on the angle of the vector
+		// since all the angles are the same
+		// The rotation added is 2*pi in order to handle negative rotations plus
+		// (Geometry.TWO_PI / count) / 2 to get the closest vertice (rounding)
+		// and also cancels out any rotation applied from the rotate methods
+		double rot = Math.atan2(localn.y, localn.x) + rotation;
+		// inverse of angles
+		double select = rot * invAngle;
+		// cast to a specific index
+		// mod count because we added 2*pi etc
+		int maxIndex = ((int) (select)) % count;
+		
+		//this is the needed vertice
+		localn = transform.getTransformed(this.vertices[maxIndex]);
+		
+		return localn;
+	}
+
+	/**	
+	 * Creates a {@link Mass} object using the geometric properties of
+	 * this {@link RegularPolygon} and the given density.
+	 * <p>
+	 * Finding the area of a {@link Polygon} can be done by using the following formula:
+	 * <p style="white-space: pre;">
+	 * r<sup>2</sup> * n * sin(2&pi / n) / 2
+	 * </p>
+	 * Finding the inertia tensor can by done by using the following equation:
+	 * <p style="white-space: pre;">
+	 * (1 + 3cot<sup>2</sup>(&pi / n)) * (M * side<sup>2</sup>) / 24
+	 * </p>
+	 * Where the mass is computed by:
+	 * <p style="white-space: pre;"> d * area</p>
+	 * @param density the density in kg/m<sup>2</sup>
+	 * @return {@link Mass} the {@link Mass} of this {@link RegularPolygon}
+	 */
+	@Override
+	public Mass createMass(double density) {
+		System.out.println(super.createMass(density).getCenter());
+		int n = this.vertices.length;
+		
+		// get the average center
+		Vector2 ac = new Vector2();
+		for (int i = 0; i < n; i++) {
+			ac.add(this.vertices[i]);
+		}
+		
+		ac.multiply(1.0 / n);
+		
+		double area = (radius * radius * count * Math.sin(Geometry.TWO_PI / count)) / 2;
+		double m = density * area;
+		
+		double sin = Math.sin(Math.PI / count);
+		double cos = Math.cos(Math.PI / count);
+		
+		double side = 2 * radius * sin;
+		double cot = cos / sin;
+		double I = (1 + 3 * cot * cot) * m * side * side / 24.0;
+		
+		return new Mass(ac, m, I);
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.geometry.Shape#createAABB(org.dyn4j.geometry.Transform)
+	 */
+	@Override
+	public AABB createAABB(Transform transform) {
+		Vector2 center = transform.getTransformed(this.center);
+		// return a new aabb
+		return new AABB(center, this.radius);
+	}
+	
+}

--- a/src/main/java/org/dyn4j/geometry/Slice.java
+++ b/src/main/java/org/dyn4j/geometry/Slice.java
@@ -38,10 +38,8 @@ import org.dyn4j.resources.Messages;
  * @since 3.1.5
  */
 public class Slice extends AbstractShape implements Convex, Shape, Transformable, DataContainer {
-	/** The total circular section in radians */
-	final double theta;
 	
-	/** Half of theta */
+	/** Half the total circular section in radians */
 	final double alpha;
 	
 	/** The radius passed in at creation */
@@ -53,8 +51,8 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 	/** The normals of the polygonal sides */
 	final Vector2[] normals;
 	
-	/** The local x axis to track local rotation */
-	final Vector2 localXAxis;
+	/** The local rotation in radians */
+	double rotation;
 	
 	/**
 	 * Validated constructor.
@@ -70,7 +68,6 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 		super(center, Math.max(center.x, center.distance(new Vector2(radius, 0).rotate(0.5*theta))));
 		
 		this.sliceRadius = radius;
-		this.theta = theta;
 		this.alpha = theta * 0.5;
 		
 		// compute the triangular section of the pie
@@ -90,8 +87,9 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 		v1.left().normalize();
 		v2.left().normalize();
 		this.normals = new Vector2[] { v1, v2 };
-
-		this.localXAxis = new Vector2(1.0, 0.0);
+		
+		// initial rotation 0 means the slice is aligned to the world space x axis
+		this.rotation = 0;
 	}
 	
 	/**
@@ -131,7 +129,7 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 		StringBuilder sb = new StringBuilder();
 		sb.append("Slice[").append(super.toString())
 		.append("|Radius=").append(this.sliceRadius)
-		.append("|Theta=").append(this.theta)
+		.append("|Theta=").append(this.getTheta())
 		.append("]");
 		return sb.toString();
 	}
@@ -210,11 +208,10 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 		Vector2 localn = transform.getInverseTransformedR(vector);
 		
 		// project the origin and two end points first
-		if (Math.abs(localn.getAngleBetween(this.localXAxis)) > this.alpha) {
+		if (Math.abs(localn.getAngleBetween(rotation)) > this.alpha) {
 			// NOTE: taken from Polygon.getFarthestPoint
-			Vector2 point = new Vector2();
 			// set the farthest point to the first one
-			point.set(this.vertices[0]);
+			int index = 0;
 			// prime the projection amount
 			double max = localn.dot(this.vertices[0]);
 			// loop through the rest of the vertices to find a further point along the axis
@@ -227,11 +224,13 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 				// check to see if the projection is greater than the last
 				if (projection > max) {
 					// otherwise this point is the farthest so far so clear the array and add it
-					point.set(v);
+					index = i;
 					// set the new maximum
 					max = projection;
 				}
 			}
+			
+			Vector2 point = new Vector2(this.vertices[index]);
 			// transform the point into world space
 			transform.transform(point);
 			return point;
@@ -250,13 +249,13 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 	@Override
 	public Feature getFarthestFeature(Vector2 vector, Transform transform) {
 		Vector2 localAxis = transform.getInverseTransformedR(vector);
-		if (Math.abs(localAxis.getAngleBetween(this.localXAxis)) <= this.alpha) {
+		if (Math.abs(localAxis.getAngleBetween(rotation)) <= this.alpha) {
 			// then its the farthest point
 			Vector2 point = this.getFarthestPoint(vector, transform);
 			return new PointFeature(point);
 		} else {
 			// check if this section is nearly a half circle
-			if ((Math.PI - this.theta) <= 1.0e-6) {
+			if ((Math.PI - this.getTheta()) <= 1.0e-6) {
 				// if so, we want to return the full back side
 				return Segment.getFarthestFeature(this.vertices[1], this.vertices[2], vector, transform);
 			}
@@ -293,7 +292,7 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 		// get the interval along the axis
 		return new Interval(d2, d1);
 	}
-
+	
 	/* (non-Javadoc)
 	 * @see org.dyn4j.geometry.Shape#createAABB(org.dyn4j.geometry.Transform)
 	 */
@@ -381,7 +380,7 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 			this.normals[i].rotate(theta);
 		}
 		// rotate the local x axis
-		this.localXAxis.rotate(theta);
+		this.rotation += theta;
 	}
 	
 	/* (non-Javadoc)
@@ -396,13 +395,13 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 			this.vertices[i].add(x, y);
 		}
 	}
-
+	
 	/**
 	 * Returns the rotation about the local center in radians.
 	 * @return double the rotation in radians
 	 */
 	public double getRotation() {
-		return Vector2.X_AXIS.getAngleBetween(this.localXAxis);
+		return rotation;
 	}
 	
 	/**
@@ -410,7 +409,7 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 	 * @return double
 	 */
 	public double getTheta() {
-		return this.theta;
+		return this.alpha * 2;
 	}
 
 	/**

--- a/src/main/java/org/dyn4j/geometry/Transform.java
+++ b/src/main/java/org/dyn4j/geometry/Transform.java
@@ -282,6 +282,40 @@ public class Transform implements Transformable {
 	}
 	
 	/**
+	 * Transforms only the x coordinate of the given {@link Vector2} and returns the result.
+	 * @param vector the {@link Vector2} to transform
+	 * @return the transformed x coordinate
+	 */
+	public double getTransformedX(Vector2 vector) {
+		return this.m00 * vector.x + this.m01 * vector.y + this.x;
+	}
+	
+	/**
+	 * Transforms only the y coordinate of the given {@link Vector2} and returns the result.
+	 * @param vector the {@link Vector2} to transform
+	 * @return the transformed y coordinate
+	 */
+	public double getTransformedY(Vector2 vector) {
+		return this.m10 * vector.x + this.m11 * vector.y + this.y;
+	}
+	
+	/**
+	 * Transforms only the x coordinate of the given {@link Vector2} and places the result in the x field of the given {@link Vector2}.
+	 * @param vector the {@link Vector2} to transform
+	 */
+	public void transformX(Vector2 vector) {
+		vector.x = this.m00 * vector.x + this.m01 * vector.y + this.x;
+	}
+	
+	/**
+	 * Transforms only the y coordinate of the given {@link Vector2} and places the result in the y field of the given {@link Vector2}.
+	 * @param vector the {@link Vector2} to transform
+	 */
+	public void transformY(Vector2 vector) {
+		vector.y = this.m10 * vector.x + this.m11 * vector.y + this.y;
+	}
+	
+	/**
 	 * Transforms the given {@link Vector2} and returns a new {@link Vector2} containing the result.
 	 * @param vector the {@link Vector2} to transform
 	 * @return {@link Vector2}

--- a/src/main/java/org/dyn4j/geometry/Vector2.java
+++ b/src/main/java/org/dyn4j/geometry/Vector2.java
@@ -749,7 +749,7 @@ public class Vector2 {
 		//return 1.0 / m;
 		return magnitude;
 	}
-	
+
 	/**
 	 * Returns the smallest angle between the given {@link Vector2}s.
 	 * <p>
@@ -759,6 +759,20 @@ public class Vector2 {
 	 */
 	public double getAngleBetween(Vector2 vector) {
 		double a = Math.atan2(vector.y, vector.x) - Math.atan2(this.y, this.x);
+		if (a > Math.PI) return a - Geometry.TWO_PI;
+		if (a < -Math.PI) return a + Geometry.TWO_PI;
+		return a;
+	}
+	
+	/**
+	 * Returns the smallest angle between the given {@link Vector2} and the given angle.
+	 * <p>
+	 * Returns the angle in radians in the range -&pi; to &pi;.
+	 * @param otherAngle the angle. Must be in the range -&pi; to &pi
+	 * @return angle in radians [-&pi;, &pi;]
+	 */
+	public double getAngleBetween(double otherAngle) {
+		double a = otherAngle - Math.atan2(this.y, this.x);
 		if (a > Math.PI) return a - Geometry.TWO_PI;
 		if (a < -Math.PI) return a + Geometry.TWO_PI;
 		return a;

--- a/src/main/java/org/dyn4j/geometry/package-info.java
+++ b/src/main/java/org/dyn4j/geometry/package-info.java
@@ -35,6 +35,7 @@
  * <li>{@link org.dyn4j.geometry.Circle}
  * <li>{@link org.dyn4j.geometry.Polygon} an arbitrary convex polygon
  * <li>{@link org.dyn4j.geometry.Rectangle}
+ * <li>{@link org.dyn4j.geometry.RegularRectangle} a specialized version of polygon
  * <li>{@link org.dyn4j.geometry.Triangle}
  * <li>{@link org.dyn4j.geometry.Slice} a piece of a circle
  * <li>{@link org.dyn4j.geometry.Ellipse}

--- a/src/test/java/org/dyn4j/geometry/GeometryTest.java
+++ b/src/test/java/org/dyn4j/geometry/GeometryTest.java
@@ -1622,9 +1622,9 @@ public class GeometryTest {
 		TestCase.assertEquals(1.000, s1.radius, 1.0e-3);
 		TestCase.assertEquals(2.000, s2.length, 1.0e-3);
 		TestCase.assertEquals(1.000, s2.capRadius * 2.0, 1.0e-3);
-		TestCase.assertEquals(2.000, s3.width, 1.0e-3);
-		TestCase.assertEquals(1.000, s3.height, 1.0e-3);
-		TestCase.assertEquals(2.000, s4.width, 1.0e-3);
+		TestCase.assertEquals(2.000, s3.getWidth(), 1.0e-3);
+		TestCase.assertEquals(1.000, s3.getHeight(), 1.0e-3);
+		TestCase.assertEquals(2.000, s4.getWidth(), 1.0e-3);
 		TestCase.assertEquals(0.500, s4.height, 1.0e-3);
 		TestCase.assertEquals(1.000, s5.sliceRadius, 1.0e-3);
 		TestCase.assertEquals(1.000, s6.radius, 1.0e-3);
@@ -1641,9 +1641,9 @@ public class GeometryTest {
 		TestCase.assertEquals(0.250, s1.radius, 1.0e-3);
 		TestCase.assertEquals(0.500, s2.length, 1.0e-3);
 		TestCase.assertEquals(0.250, s2.capRadius * 2.0, 1.0e-3);
-		TestCase.assertEquals(0.500, s3.width, 1.0e-3);
-		TestCase.assertEquals(0.250, s3.height, 1.0e-3);
-		TestCase.assertEquals(0.500, s4.width, 1.0e-3);
+		TestCase.assertEquals(0.500, s3.getWidth(), 1.0e-3);
+		TestCase.assertEquals(0.250, s3.getHeight(), 1.0e-3);
+		TestCase.assertEquals(0.500, s4.getWidth(), 1.0e-3);
 		TestCase.assertEquals(0.125, s4.height, 1.0e-3);
 		TestCase.assertEquals(0.250, s5.sliceRadius, 1.0e-3);
 		TestCase.assertEquals(0.250, s6.radius, 1.0e-3);


### PR DESCRIPTION
This pull request contains a variety of optimizations for the following shapes:

- Ellipse
- HalfEllipse
- Polygon
- Rectangle
- Slice

Included are both space (reducing variables needed) and time (faster algorithms or minor performance adjustments) optimizations.

In more detail:
- From the **Ellipse**, **HalfEllipse** and **Slice** classes replaced the Vector2 localAxis with a rotation variable, representing the same thing but more efficiently. Also allows computations without invloving atan2 which is usually quite slow.
- Also removed some variables that where logical duplicates. For example Ellipse was storing both widht, height and halfWidth, halfHeight although width and height where not used almost anywhere and could be replaced by halfWidth * 2 and halfHeight * 2 without any performance pentalty.
- Faster calculation of AABB for the Ellipse class
- Added a method override in **Rectangle** for more efficient calculation of its AABB
- Minor improvements in Polygon class
- Couple more small things

Also a 'new' Shape **RegulalPolygon** is added. Although `Geometry.createPolygonalCircle` can create the same RegulalPolygon shape, the seperate class contains some big speed/space improvements (more details in the class file).
Specifically for a N-sided regular polygon the class provides implementations of `getFarthestFeature`, `getFarthestPoint` and `createAABB` that run in O(1) time instead of O(N) that the Polygon class provides.
Also includes much faster mass creation.
