### PR TITLE
More optimizations and AABB unpack

### DIFF
--- a/src/main/java/org/dyn4j/collision/AbstractCollidable.java
+++ b/src/main/java/org/dyn4j/collision/AbstractCollidable.java
@@ -377,7 +377,7 @@ public abstract class AbstractCollidable<T extends Fixture> implements Collidabl
 			// return the aabb
 			return aabb;
 		}
-		return new AABB(new Vector2(0.0, 0.0), new Vector2(0.0, 0.0));
+		return new AABB(0.0, 0.0, 0.0, 0.0);
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/dyn4j/collision/AxisAlignedBounds.java
+++ b/src/main/java/org/dyn4j/collision/AxisAlignedBounds.java
@@ -79,11 +79,7 @@ public class AxisAlignedBounds extends AbstractBounds implements Bounds, Transla
 		AABB aabbBody = collidable.createAABB();
 		
 		// test the projections for overlap
-		if (aabbBounds.overlaps(aabbBody)) {
-			return false;
-		}
-		
-		return true;
+		return !aabbBounds.overlaps(aabbBody);
 	}
 	
 	/**

--- a/src/main/java/org/dyn4j/collision/broadphase/DynamicAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/DynamicAABBTree.java
@@ -296,16 +296,8 @@ public class DynamicAABBTree<E extends Collidable<T>, T extends Fixture> extends
 		double y1 = s.y;
 		double y2 = s.y + d.y * l;
 		
-		// create the min and max points
-		Vector2 min = new Vector2(
-				Math.min(x1, x2),
-				Math.min(y1, y2));
-		Vector2 max = new Vector2(
-				Math.max(x1, x2),
-				Math.max(y1, y2));
-		
 		// create the aabb
-		AABB aabb = new AABB(min, max);
+		AABB aabb = AABB.createAABBFromPoints(x1, y1, x2, y2);
 		
 		// precompute
 		double invDx = 1.0 / d.x;

--- a/src/main/java/org/dyn4j/collision/broadphase/Sap.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/Sap.java
@@ -363,16 +363,8 @@ public class Sap<E extends Collidable<T>, T extends Fixture> extends AbstractBro
 		double y1 = s.y;
 		double y2 = s.y + d.y * l;
 		
-		// create the min and max points
-		Vector2 min = new Vector2(
-				Math.min(x1, x2),
-				Math.min(y1, y2));
-		Vector2 max = new Vector2(
-				Math.max(x1, x2),
-				Math.max(y1, y2));
-		
 		// create the aabb
-		AABB aabb = new AABB(min, max);
+		AABB aabb = AABB.createAABBFromPoints(x1, y1, x2, y2);
 		
 		double invDx = 1.0 / d.x;
 		double invDy = 1.0 / d.y;

--- a/src/main/java/org/dyn4j/dynamics/Body.java
+++ b/src/main/java/org/dyn4j/dynamics/Body.java
@@ -1237,13 +1237,11 @@ public class Body extends AbstractCollidable<BodyFixture> implements Collidable<
 		Vector2 fCenter = finalTransform.getTransformed(this.mass.getCenter());
 		// return an AABB containing both points (expanded into circles by the
 		// rotation disc radius)
-		return new AABB(
-				new Vector2(
-					Math.min(iCenter.x, fCenter.x) - this.radius,
-					Math.min(iCenter.y, fCenter.y) - this.radius),
-				new Vector2(
-					Math.max(iCenter.x, fCenter.x) + this.radius,
-					Math.max(iCenter.y, fCenter.y) + this.radius));
+		
+		AABB sweptAABB = AABB.createAABBFromPoints(iCenter, fCenter);
+		sweptAABB.expand(this.radius * 2);
+		
+		return sweptAABB;
 	}
 	
 	/**

--- a/src/main/java/org/dyn4j/geometry/AABB.java
+++ b/src/main/java/org/dyn4j/geometry/AABB.java
@@ -51,10 +51,26 @@ public class AABB implements Translatable {
 	/** The maximum extent */
 	protected double maxX, maxY;
 	
+	/**
+	 * Method to create the valid AABB defined by the two points point1 and point2.
+	 * 
+	 * @param point1 the first point
+	 * @param point2 the second point
+	 * @return The one and only one valid AABB formed by point1 and point2
+	 */
 	public static AABB createAABBFromPoints(Vector2 point1, Vector2 point2) {
 		return createAABBFromPoints(point1.x, point1.y, point2.x, point2.y);
 	}
 	
+	/**
+	 * Method to create the valid AABB defined by the two points A(point1x, point1y) and B(point2x, point2y).
+	 * 
+	 * @param point1x The x coordinate of point A
+	 * @param point1y The y coordinate of point A
+	 * @param point2x The x coordinate of point B
+	 * @param point2y The y coordinate of point B
+	 * @return The one and only one valid AABB formed by A and B
+	 */
 	public static AABB createAABBFromPoints(double point1x, double point1y, double point2x, double point2y) {
 		if (point2x < point1x) {
 			double temp = point1x;

--- a/src/main/java/org/dyn4j/geometry/AABB.java
+++ b/src/main/java/org/dyn4j/geometry/AABB.java
@@ -46,10 +46,30 @@ import org.dyn4j.resources.Messages;
  */
 public class AABB implements Translatable {
 	/** The minimum extent */
-	protected final Vector2 min;
+	protected double minX, minY;
 	
 	/** The maximum extent */
-	protected final Vector2 max;
+	protected double maxX, maxY;
+	
+	public static AABB createAABBFromPoints(Vector2 point1, Vector2 point2) {
+		return createAABBFromPoints(point1.x, point1.y, point2.x, point2.y);
+	}
+	
+	public static AABB createAABBFromPoints(double point1x, double point1y, double point2x, double point2y) {
+		if (point2x < point1x) {
+			double temp = point1x;
+			point1x = point2x;
+			point2x = temp;
+		}
+		
+		if (point2y < point1y) {
+			double temp = point1y;
+			point1y = point2y;
+			point2y = temp;
+		}
+		
+		return new AABB(point1x, point1y, point2x, point2y);
+	}
 	
 	/**
 	 * Full constructor.
@@ -59,7 +79,13 @@ public class AABB implements Translatable {
 	 * @param maxY the maximum y extent
 	 */
 	public AABB(double minX, double minY, double maxX, double maxY) {
-		this(new Vector2(minX, minY), new Vector2(maxX, maxY));
+		// check the min and max
+		if (minX > maxX || minY > maxY) throw new IllegalArgumentException(Messages.getString("geometry.aabb.invalidMinMax"));
+		
+		this.minX = minX;
+		this.minY = minY;
+		this.maxX = maxX;
+		this.maxY = maxY;
 	}
 	
 	/**
@@ -69,10 +95,7 @@ public class AABB implements Translatable {
 	 * @throws IllegalArgumentException if either coordinate of the given min is greater than the given max
 	 */
 	public AABB(Vector2 min, Vector2 max) {
-		// check the min and max
-		if (min.x > max.x || min.y > max.y) throw new IllegalArgumentException(Messages.getString("geometry.aabb.invalidMinMax"));
-		this.min = min;
-		this.max = max;
+		this(min.x, min.y, max.x, max.y);
 	}
 	
 	/**
@@ -95,12 +118,17 @@ public class AABB implements Translatable {
 	 */
 	public AABB(Vector2 center, double radius) {
 		if (radius < 0) throw new IllegalArgumentException(Messages.getString("geometry.aabb.invalidRadius"));
+		
 		if (center == null) {
-			this.min = new Vector2(-radius, -radius);
-			this.max = new Vector2( radius,  radius);
+			this.minX = -radius;
+			this.minY = -radius;
+			this.maxX =  radius;
+			this.maxY =  radius;
 		} else {
-			this.min = new Vector2(center.x - radius, center.y - radius);
-			this.max = new Vector2(center.x + radius, center.y + radius);
+			this.minX = center.x - radius;
+			this.minY = center.y - radius;
+			this.maxX = center.x + radius;
+			this.maxY = center.y + radius;
 		}
 	}
 	
@@ -110,8 +138,10 @@ public class AABB implements Translatable {
 	 * @since 3.1.1
 	 */
 	public AABB(AABB aabb) {
-		this.min = aabb.min.copy();
-		this.max = aabb.max.copy();
+		this.minX = aabb.minX;
+		this.minY = aabb.minY;
+		this.maxX = aabb.maxX;
+		this.maxY = aabb.maxY;
 	}
 	
 	/**
@@ -122,10 +152,10 @@ public class AABB implements Translatable {
 	 * @since 3.2.5
 	 */
 	public AABB set(AABB aabb) {
-		this.min.x = aabb.min.x;
-		this.min.y = aabb.min.y;
-		this.max.x = aabb.max.x;
-		this.max.y = aabb.max.y;
+		this.minX = aabb.minX;
+		this.minY = aabb.minY;
+		this.maxX = aabb.maxX;
+		this.maxY = aabb.maxY;
 		return this;
 	}
 	
@@ -135,8 +165,18 @@ public class AABB implements Translatable {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("AABB[Min=").append(this.min)
-		.append("|Max=").append(this.max)
+		sb.append("AABB[Min=")
+		.append("(")
+		.append(this.minX)
+		.append(", ")
+		.append(this.minY)
+		.append(")")
+		.append("|Max=")
+		.append("(")
+		.append(this.maxX)
+		.append(", ")
+		.append(this.maxY)
+		.append(")")
 		.append("]");
 		return sb.toString();
 	}
@@ -146,16 +186,17 @@ public class AABB implements Translatable {
 	 */
 	@Override
 	public void translate(double x, double y) {
-		this.max.add(x, y);
-		this.min.add(x, y);
+		this.minX += x;
+		this.minY += y;
+		this.maxX += x;
+		this.maxY += y;
 	}
 	
 	/* (non-Javadoc)
 	 * @see org.dyn4j.geometry.Translatable#translate(org.dyn4j.geometry.Vector2)
 	 */
 	public void translate(Vector2 translation) {
-		this.max.add(translation);
-		this.min.add(translation);
+		translate(translation.x, translation.y);
 	}
 	
 	/**
@@ -167,8 +208,10 @@ public class AABB implements Translatable {
 	 */
 	public AABB getTranslated(Vector2 translation) {
 		return new AABB(
-				this.min.sum(translation),
-				this.max.sum(translation));
+				this.minX + translation.x,
+				this.minY + translation.y,
+				this.maxX + translation.x,
+				this.maxY + translation.y);
 	}
 	
 	/**
@@ -177,7 +220,7 @@ public class AABB implements Translatable {
 	 * @since 3.0.1
 	 */
 	public double getWidth() {
-		return this.max.x - this.min.x;
+		return this.maxX - this.minX;
 	}
 	
 	/**
@@ -186,7 +229,7 @@ public class AABB implements Translatable {
 	 * @since 3.0.1
 	 */
 	public double getHeight() {
-		return this.max.y - this.min.y;
+		return this.maxY - this.minY;
 	}
 	
 	/**
@@ -194,7 +237,7 @@ public class AABB implements Translatable {
 	 * @return double
 	 */
 	public double getPerimeter() {
-		return 2 * (this.max.x - this.min.x + this.max.y - this.min.y);
+		return 2 * (this.maxX - this.minX + this.maxY - this.minY);
 	}
 	
 	/**
@@ -202,7 +245,7 @@ public class AABB implements Translatable {
 	 * @return double
 	 */
 	public double getArea() {
-		return (this.max.x - this.min.x) * (this.max.y - this.min.y);
+		return (this.maxX - this.minX) * (this.maxY - this.minY);
 	}
 	
 	/**
@@ -213,10 +256,10 @@ public class AABB implements Translatable {
 	 * @return {@link AABB}
 	 */
 	public AABB union(AABB aabb) {
-		this.min.x = Math.min(this.min.x, aabb.min.x);
-		this.min.y = Math.min(this.min.y, aabb.min.y);
-		this.max.x = Math.max(this.max.x, aabb.max.x);
-		this.max.y = Math.max(this.max.y, aabb.max.y);
+		this.minX = Math.min(this.minX, aabb.minX);
+		this.minY = Math.min(this.minY, aabb.minY);
+		this.maxX = Math.max(this.maxX, aabb.maxX);
+		this.maxY = Math.max(this.maxY, aabb.maxY);
 		return this;
 	}
 	
@@ -227,15 +270,11 @@ public class AABB implements Translatable {
 	 * @return {@link AABB} the resulting union
 	 */
 	public AABB getUnion(AABB aabb) {
-		Vector2 min = new Vector2();
-		Vector2 max = new Vector2();
-		
-		min.x = Math.min(this.min.x, aabb.min.x);
-		min.y = Math.min(this.min.y, aabb.min.y);
-		max.x = Math.max(this.max.x, aabb.max.x);
-		max.y = Math.max(this.max.y, aabb.max.y);
-		
-		return new AABB(min, max);
+		return new AABB(
+				Math.min(this.minX, aabb.minX),
+				Math.min(this.minY, aabb.minY),
+				Math.max(this.maxX, aabb.maxX),
+				Math.max(this.maxY, aabb.maxY));
 	}
 	
 	/**
@@ -249,19 +288,19 @@ public class AABB implements Translatable {
 	 * @since 3.1.1
 	 */
 	public AABB intersection(AABB aabb) {
-		this.min.x = Math.max(this.min.x, aabb.min.x);
-		this.min.y = Math.max(this.min.y, aabb.min.y);
-		this.max.x = Math.min(this.max.x, aabb.max.x);
-		this.max.y = Math.min(this.max.y, aabb.max.y);
+		this.minX = Math.max(this.minX, aabb.minX);
+		this.minY = Math.max(this.minY, aabb.minY);
+		this.maxX = Math.min(this.maxX, aabb.maxX);
+		this.maxY = Math.min(this.maxY, aabb.maxY);
 		
 		// check for a bad AABB
-		if (this.min.x > this.max.x || this.min.y > this.max.y) {
+		if (this.minX > this.maxX || this.minY > this.maxY) {
 			// the two AABBs were not overlapping
 			// set this AABB to a degenerate one
-			this.min.x = 0.0;
-			this.min.y = 0.0;
-			this.max.x = 0.0;
-			this.max.y = 0.0;
+			this.minX = 0.0;
+			this.minY = 0.0;
+			this.maxX = 0.0;
+			this.maxY = 0.0;
 		}
 		
 		return this;
@@ -278,21 +317,18 @@ public class AABB implements Translatable {
 	 * @since 3.1.1
 	 */
 	public AABB getIntersection(AABB aabb) {
-		Vector2 min = new Vector2();
-		Vector2 max = new Vector2();
-		
-		min.x = Math.max(this.min.x, aabb.min.x);
-		min.y = Math.max(this.min.y, aabb.min.y);
-		max.x = Math.min(this.max.x, aabb.max.x);
-		max.y = Math.min(this.max.y, aabb.max.y);
+		double minx = Math.max(this.minX, aabb.minX);
+		double miny = Math.max(this.minY, aabb.minY);
+		double maxx = Math.min(this.maxX, aabb.maxX);
+		double maxy = Math.min(this.maxY, aabb.maxY);
 		
 		// check for a bad AABB
-		if (min.x > max.x || min.y > max.y) {
+		if (minx > maxx || miny > maxy) {
 			// the two AABBs were not overlapping
 			// return a degenerate one
-			return new AABB(new Vector2(), new Vector2());
+			return new AABB(0.0, 0.0, 0.0, 0.0);
 		}
-		return new AABB(min, max);
+		return new AABB(minx, miny, maxx, maxy);
 	}
 	
 	/**
@@ -308,24 +344,24 @@ public class AABB implements Translatable {
 	 */
 	public AABB expand(double expansion) {
 		double e = expansion * 0.5;
-		this.min.x -= e;
-		this.min.y -= e;
-		this.max.x += e;
-		this.max.y += e;
+		this.minX -= e;
+		this.minY -= e;
+		this.maxX += e;
+		this.maxY += e;
 		// we only need to verify the new aabb if the expansion
 		// was inwardly
 		if (expansion < 0.0) {
 			// if the aabb is invalid then set the min/max(es) to
 			// the middle value of their current values
-			if (this.min.x > this.max.x) {
-				double mid = (this.min.x + this.max.x) * 0.5;
-				this.min.x = mid;
-				this.max.x = mid;
+			if (this.minX > this.maxX) {
+				double mid = (this.minX + this.maxX) * 0.5;
+				this.minX = mid;
+				this.maxX = mid;
 			}
-			if (this.min.y > this.max.y) {
-				double mid = (this.min.y + this.max.y) * 0.5;
-				this.min.y = mid;
-				this.max.y = mid;
+			if (this.minY > this.maxY) {
+				double mid = (this.minY + this.maxY) * 0.5;
+				this.minY = mid;
+				this.maxY = mid;
 			}
 		}
 		return this;
@@ -345,10 +381,10 @@ public class AABB implements Translatable {
 	 */
 	public AABB getExpanded(double expansion) {
 		double e = expansion * 0.5;
-		double minx = this.min.x - e;
-		double miny = this.min.y - e;
-		double maxx = this.max.x + e;
-		double maxy = this.max.y + e;
+		double minx = this.minX - e;
+		double miny = this.minY - e;
+		double maxx = this.maxX + e;
+		double maxy = this.maxY + e;
 		// we only need to verify the new aabb if the expansion
 		// was inwardly
 		if (expansion < 0.0) {
@@ -365,9 +401,7 @@ public class AABB implements Translatable {
 				maxy = mid;
 			}
 		}
-		return new AABB(
-				new Vector2(minx, miny), 
-				new Vector2(maxx, maxy));
+		return new AABB(minx, miny, maxx, maxy);
 	}
 	
 	/**
@@ -376,19 +410,10 @@ public class AABB implements Translatable {
 	 * @return boolean true if the {@link AABB}s overlap
 	 */
 	public boolean overlaps(AABB aabb) {
-		// check for overlap along the x-axis
-		if (this.min.x > aabb.max.x || this.max.x < aabb.min.x) {
-			// the aabbs do not overlap along the x-axis
-			return false;
-		}
-		
-		// check for overlap along the y-axis
-		if (this.min.y > aabb.max.y || this.max.y < aabb.min.y) {
-			// the aabbs do not overlap along the y-axis
-			return false;
-		}
-		
-		return true;
+		return this.minX <= aabb.maxX &&
+				this.maxX >= aabb.minX &&
+				this.minY <= aabb.maxY &&
+				this.maxY >= aabb.minY;
 	}
 	
 	/**
@@ -397,12 +422,10 @@ public class AABB implements Translatable {
 	 * @return boolean
 	 */
 	public boolean contains(AABB aabb) {
-		if (this.min.x <= aabb.min.x && this.max.x >= aabb.max.x) {
-			if (this.min.y <= aabb.min.y && this.max.y >= aabb.max.y) {
-				return true;
-			}
-		}
-		return false;
+		return this.minX <= aabb.minX &&
+				this.maxX >= aabb.maxX &&
+				this.minY <= aabb.minY &&
+				this.maxY >= aabb.maxY;
 	}
 	
 	/**
@@ -423,12 +446,10 @@ public class AABB implements Translatable {
 	 * @since 3.1.1
 	 */
 	public boolean contains(double x, double y) {
-		if (this.min.x <= x && this.max.x >= x) {
-			if (this.min.y <= y && this.max.y >= y) {
-				return true;
-			}
-		}
-		return false;
+		return this.minX <= x &&
+				this.maxX >= x &&
+				this.minY <= y &&
+				this.maxY >= y;
 	}
 	
 	/**
@@ -440,7 +461,7 @@ public class AABB implements Translatable {
 	 * @since 3.1.1
 	 */
 	public boolean isDegenerate() {
-		return this.min.x == this.max.x || this.min.y == this.max.y;
+		return this.minX == this.maxX || this.minY == this.maxY;
 	}
 	
 	/**
@@ -455,7 +476,7 @@ public class AABB implements Translatable {
 	 * @see #isDegenerate()
 	 */
 	public boolean isDegenerate(double error) {
-		return Math.abs(this.max.x - this.min.x) <= error || Math.abs(this.max.y - this.min.y) <= error;
+		return Math.abs(this.maxX - this.minX) <= error || Math.abs(this.maxY - this.minY) <= error;
 	}
 	
 	/**
@@ -463,7 +484,7 @@ public class AABB implements Translatable {
 	 * @return double
 	 */
 	public double getMinX() {
-		return this.min.x;
+		return this.minX;
 	}
 	
 	/**
@@ -471,7 +492,7 @@ public class AABB implements Translatable {
 	 * @return double
 	 */
 	public double getMaxX() {
-		return this.max.x;
+		return this.maxX;
 	}
 	
 	/**
@@ -479,7 +500,7 @@ public class AABB implements Translatable {
 	 * @return double
 	 */
 	public double getMaxY() {
-		return this.max.y;
+		return this.maxY;
 	}
 	
 	/**
@@ -487,6 +508,6 @@ public class AABB implements Translatable {
 	 * @return double
 	 */
 	public double getMinY() {
-		return this.min.y;
+		return this.minY;
 	}
 }

--- a/src/main/java/org/dyn4j/geometry/Capsule.java
+++ b/src/main/java/org/dyn4j/geometry/Capsule.java
@@ -288,10 +288,21 @@ public class Capsule extends AbstractShape implements Convex, Shape, Transformab
 	 */
 	@Override
 	public AABB createAABB(Transform transform) {
-		Interval x = this.project(Vector2.X_AXIS, transform);
-		Interval y = this.project(Vector2.Y_AXIS, transform);
+		// Inlined projection of x axis
+		// Interval x = this.project(Vector2.X_AXIS, transform);
+		Vector2 p1 = this.getFarthestPoint(Vector2.X_AXIS, transform);
+		double c = transform.getTransformedX(this.center);
+		double minX = 2 * c - p1.x;
+		double maxX = p1.x;
 		
-		return new AABB(x.getMin(), y.getMin(), x.getMax(), y.getMax());
+		// Inlined projection of y axis
+		// Interval y = this.project(Vector2.Y_AXIS, transform);
+		p1 = this.getFarthestPoint(Vector2.Y_AXIS, transform);
+		c = transform.getTransformedY(this.center);
+		double minY = 2 * c - p1.y;
+		double maxY = p1.y;
+		
+		return new AABB(minX, minY, maxX, maxY);
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/dyn4j/geometry/Ellipse.java
+++ b/src/main/java/org/dyn4j/geometry/Ellipse.java
@@ -156,13 +156,31 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 		// convert the world space vector(n) to local space
 		Vector2 localAxis = transform.getInverseTransformedR(vector);
 		
-		// include local rotation
-		double cos = Math.cos(this.rotation);
-		double sin = Math.sin(this.rotation);
+		if (this.rotation == 0) {
+			getFarthestPointHelper(localAxis);
+		} else {
+			double cos = Math.cos(this.rotation);
+			double sin = Math.sin(this.rotation);
+			
+			// invert the local rotation
+			// cos(-x) = cos(x), sin(-x) = -sin(x)
+			localAxis.rotate(cos, -sin);	
+			
+			getFarthestPointHelper(localAxis);
+			
+			// include local rotation
+			localAxis.rotate(cos, sin);
+		}
 		
-		// invert the local rotation
-		// cos(-x) = cos(x), sin(-x) = -sin(x)
-		localAxis.rotate(cos, -sin);
+		// add the radius along the vector to the center to get the farthest point
+		localAxis.add(this.center);
+		// then finally convert back into world space coordinates
+		transform.transform(localAxis);
+		
+		return localAxis;
+	}
+
+	private void getFarthestPointHelper(Vector2 localAxis) {
 		// an ellipse is a circle with a non-uniform scaling transformation applied
 		// so we can achieve that by scaling the input axis by the major and minor
 		// axis lengths
@@ -170,15 +188,9 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 		localAxis.y *= this.halfHeight;
 		// then normalize it
 		localAxis.normalize();
-		// add the radius along the vector to the center to get the farthest point
-		Vector2 p = new Vector2(localAxis.x * this.halfWidth, localAxis.y  * this.halfHeight);
-		// include local rotation
-		// invert the local rotation
-		p.rotate(cos, sin);
-		p.add(this.center);
-		// then finally convert back into world space coordinates
-		transform.transform(p);
-		return p;
+		// then scale again to get a point in the ellipse
+		localAxis.x *= this.halfWidth;
+		localAxis.y *= this.halfHeight;
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/org/dyn4j/geometry/Ellipse.java
+++ b/src/main/java/org/dyn4j/geometry/Ellipse.java
@@ -165,9 +165,14 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 		return localAxis;
 	}
 	
+	/*
+	 * Performs all the logic of getFarthestPoint except for the needed world space transformations.
+	 * Hence all calculations are in local axis
+	 */
 	private Vector2 getFarthestPointImpl(Vector2 localAxis) {
 		// localAxis is already in local coordinates
 		if (this.rotation == 0) {
+			// This is the case most of the time, and saves a lot of computations
 			getFarthestPointHelper(localAxis);
 		} else {
 			double cos = Math.cos(this.rotation);
@@ -189,6 +194,10 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 		return localAxis;
 	}
 	
+	/*
+	 * Finds the farthest point in the ellipse in the direction of localAxis
+	 * Used to avoid code duplication in getFarthestPointImpl
+	 */
 	private void getFarthestPointHelper(Vector2 localAxis) {
 		// an ellipse is a circle with a non-uniform scaling transformation applied
 		// so we can achieve that by scaling the input axis by the major and minor

--- a/src/main/java/org/dyn4j/geometry/Ellipse.java
+++ b/src/main/java/org/dyn4j/geometry/Ellipse.java
@@ -251,7 +251,9 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 		
 		// Equivalent of transform.getInverseTransformedR(Vector2.X_AXIS)
 		Vector2 temp = new Vector2(transform.cost, -transform.sint);
+		// Equivalent of p1x = this.getFarthestPoint(Vector2.X_AXIS, transform).x;
 		double p1x = transform.getTransformedX(getFarthestPointImpl(temp));	
+		
 		double c = transform.getTransformedX(this.center);
 		double minx = 2 * c - p1x;
 		double maxx = p1x;
@@ -261,7 +263,10 @@ public class Ellipse extends AbstractShape implements Convex, Shape, Transformab
 		
 		// Equivalent of transform.getInverseTransformedR(Vector2.Y_AXIS)
 		temp = new Vector2(transform.sint, transform.cost);
+		// Equivalent of p1y = this.getFarthestPoint(Vector2.Y_AXIS, transform).y;
 		double p1y = transform.getTransformedY(getFarthestPointImpl(temp));	
+		
+		// Rest of projection code
 		c = transform.getTransformedY(this.center);
 		double miny = 2 * c - p1y;
 		double maxy = p1y;

--- a/src/main/java/org/dyn4j/geometry/HalfEllipse.java
+++ b/src/main/java/org/dyn4j/geometry/HalfEllipse.java
@@ -253,10 +253,17 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	 */
 	@Override
 	public AABB createAABB(Transform transform) {
-		Interval x = this.project(Vector2.X_AXIS, transform);
-		Interval y = this.project(Vector2.Y_AXIS, transform);
+		// Inlined projection of x axis
+		// Interval x = this.project(Vector2.X_AXIS, transform);
+		double minX = this.getFarthestPoint(Vector2.INV_X_AXIS, transform).x;
+		double maxX = this.getFarthestPoint(Vector2.X_AXIS, transform).x;
 		
-		return new AABB(x.getMin(), y.getMin(), x.getMax(), y.getMax());
+		// Inlined projection of y axis
+		// Interval y = this.project(Vector2.Y_AXIS, transform);
+		double minY = this.getFarthestPoint(Vector2.INV_Y_AXIS, transform).y;
+		double maxY = this.getFarthestPoint(Vector2.Y_AXIS, transform).y;
+		
+		return new AABB(minX, minY, maxX, maxY);
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/org/dyn4j/geometry/HalfEllipse.java
+++ b/src/main/java/org/dyn4j/geometry/HalfEllipse.java
@@ -191,6 +191,10 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 		return localAxis;
 	}
 	
+	/*
+	 * Performs all the logic of getFarthestPoint except for the needed world space transformations.
+	 * Hence all calculations are in local axis
+	 */
 	private Vector2 getFarthestPointImpl(Vector2 localAxis) {
 		// localAxis is already in local coordinates
 		

--- a/src/main/java/org/dyn4j/geometry/HalfEllipse.java
+++ b/src/main/java/org/dyn4j/geometry/HalfEllipse.java
@@ -284,20 +284,26 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	public AABB createAABB(Transform transform) {
 		// Inlined projection of x axis
 		
-		// Equivalent of transform.getInverseTransformedR(Vector2.X_AXIS)
+		// Equivalent of temp = transform.getInverseTransformedR(Vector2.X_AXIS)
 		Vector2 temp = new Vector2(transform.cost, -transform.sint);
+		// Equivalent of maxX = this.project(Vector2.X_AXIS, transform).getMax();
 		double maxX = transform.getTransformedX(getFarthestPointImpl(temp));
-		// Equivalent of transform.getInverseTransformedR(Vector2.INV_X_AXIS)
+		
+		// Equivalent of temp = transform.getInverseTransformedR(Vector2.INV_X_AXIS)
 		temp.set(-transform.cost, transform.sint);
+		// Equivalent of minX = this.project(Vector2.X_AXIS, transform).getMin();
 		double minX = transform.getTransformedX(getFarthestPointImpl(temp));
 		
 		// Inlined projection of y axis
 		
-		// Equivalent of transform.getInverseTransformedR(Vector2.Y_AXIS)
+		// Equivalent of temp = transform.getInverseTransformedR(Vector2.Y_AXIS)
 		temp.set(transform.sint, transform.cost);
+		// Equivalent of maxY = this.project(Vector2.Y_AXIS, transform).getMax();
 		double maxY = transform.getTransformedY(getFarthestPointImpl(temp));
-		// Equivalent of transform.getInverseTransformedR(Vector2.INV_Y_AXIS)
+		
+		// Equivalent of temp = transform.getInverseTransformedR(Vector2.INV_Y_AXIS)
 		temp.set(-transform.sint, -transform.cost);
+		// Equivalent of minY = this.project(Vector2.Y_AXIS, transform).getMin();
 		double minY = transform.getTransformedY(getFarthestPointImpl(temp));
 		
 		return new AABB(minX, minY, maxX, maxY);

--- a/src/main/java/org/dyn4j/geometry/HalfEllipse.java
+++ b/src/main/java/org/dyn4j/geometry/HalfEllipse.java
@@ -279,19 +279,21 @@ public class HalfEllipse extends AbstractShape implements Convex, Shape, Transfo
 	@Override
 	public AABB createAABB(Transform transform) {
 		// Inlined projection of x axis
+		
 		// Equivalent of transform.getInverseTransformedR(Vector2.X_AXIS)
 		Vector2 temp = new Vector2(transform.cost, -transform.sint);
 		double maxX = transform.getTransformedX(getFarthestPointImpl(temp));
 		// Equivalent of transform.getInverseTransformedR(Vector2.INV_X_AXIS)
-		temp.negate();
+		temp.set(-transform.cost, transform.sint);
 		double minX = transform.getTransformedX(getFarthestPointImpl(temp));
 		
 		// Inlined projection of y axis
+		
 		// Equivalent of transform.getInverseTransformedR(Vector2.Y_AXIS)
-		temp = new Vector2(transform.sint, transform.cost);
+		temp.set(transform.sint, transform.cost);
 		double maxY = transform.getTransformedY(getFarthestPointImpl(temp));
 		// Equivalent of transform.getInverseTransformedR(Vector2.INV_Y_AXIS)
-		temp.negate();
+		temp.set(-transform.sint, -transform.cost);
 		double minY = transform.getTransformedY(getFarthestPointImpl(temp));
 		
 		return new AABB(minX, minY, maxX, maxY);

--- a/src/main/java/org/dyn4j/geometry/Segment.java
+++ b/src/main/java/org/dyn4j/geometry/Segment.java
@@ -754,29 +754,11 @@ public class Segment extends AbstractShape implements Convex, Wound, Shape, Tran
 	 */
 	@Override
 	public AABB createAABB(Transform transform) {
-		double vx = 0.0;
-		double vy = 0.0;
-    	// get the first point
-		Vector2 p = transform.getTransformed(this.vertices[0]);
-		// project the point onto the vector
-    	double minX = Vector2.X_AXIS.dot(p);
-    	double maxX = minX;
-    	double minY = Vector2.Y_AXIS.dot(p);
-    	double maxY = minY;
-
-		// get the other point
-		p = transform.getTransformed(this.vertices[1]);
-		// project it onto the vector
-        vx = Vector2.X_AXIS.dot(p);
-        vy = Vector2.Y_AXIS.dot(p);
-        
-        // compare the x values
-        minX = Math.min(minX, vx);
-        maxX = Math.max(maxX, vx);
-        minY = Math.min(minY, vy);
-        maxY = Math.max(maxY, vy);
-        
+    	// get the transformed points
+		Vector2 p0 = transform.getTransformed(this.vertices[0]);
+		Vector2 p1 = transform.getTransformed(this.vertices[1]);
+		
 		// create the aabb
-		return new AABB(minX, minY, maxX, maxY);
+		return AABB.createAABBFromPoints(p0, p1);
 	}
 }

--- a/src/main/java/org/dyn4j/geometry/Slice.java
+++ b/src/main/java/org/dyn4j/geometry/Slice.java
@@ -298,10 +298,17 @@ public class Slice extends AbstractShape implements Convex, Shape, Transformable
 	 */
 	@Override
 	public AABB createAABB(Transform transform) {
-		Interval x = this.project(Vector2.X_AXIS, transform);
-		Interval y = this.project(Vector2.Y_AXIS, transform);
+		// Inlined projection of x axis
+		// Interval x = this.project(Vector2.X_AXIS, transform);
+		double minX = this.getFarthestPoint(Vector2.INV_X_AXIS, transform).x;
+		double maxX = this.getFarthestPoint(Vector2.X_AXIS, transform).x;
 		
-		return new AABB(x.getMin(), y.getMin(), x.getMax(), y.getMax());
+		// Inlined projection of y axis
+		// Interval y = this.project(Vector2.Y_AXIS, transform);
+		double minY = this.getFarthestPoint(Vector2.INV_Y_AXIS, transform).y;
+		double maxY = this.getFarthestPoint(Vector2.Y_AXIS, transform).y;
+		
+		return new AABB(minX, minY, maxX, maxY);
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/org/dyn4j/geometry/Vector2.java
+++ b/src/main/java/org/dyn4j/geometry/Vector2.java
@@ -49,6 +49,12 @@ public class Vector2 {
 	/** A vector representing the y-axis; this vector should not be changed at runtime; used internally */
 	static final Vector2 Y_AXIS = new Vector2(0.0, 1.0);
 	
+	/** A vector representing the inverse x-axis; this vector should not be changed at runtime; used internally */
+	static final Vector2 INV_X_AXIS = new Vector2(-1.0, 0.0);
+	
+	/** A vector representing the inverse y-axis; this vector should not be changed at runtime; used internally */
+	static final Vector2 INV_Y_AXIS = new Vector2(0.0, -1.0);
+	
 	/** The magnitude of the x component of this {@link Vector2} */
 	public double x;
 	


### PR DESCRIPTION
I implemented the AABB unpack thing, but ended making quite more changes on the way. Everything in this pull request is an optimization; No new functionallity is added.
Changes include:

- Unpack Vector2 in AABB to 4 doubles; results are good with this
- Add static methods for creation of AABBs of two points; this makes some bits in the code more clear but also is faster than the previous Math.min/Math.max chain
- Added two static fields INV_X_AXIS and INV_Y_AXIS; I initially used those, but afterwards didn't need them. Still it does not harm to have them declared. Can be ommited
-  One round of optimizations for createAABB of some shapes: Capsule, Slice, Segment and HalfEllipse; results are good with this one, speed increase is measurable
- Even more optimizations for getFarthestPoint and createAABB for Ellipse and HalfEllipse; results very good here, measurable as well

I got some good results from the above. For example synthetic tests with a lot of Ellipse shapes run 30-40% faster (total simulation time on my pc).
There is some tradeof in readability for the createAABB methods of Ellipse and HalfEllipse, since I applied a lot of 'manual inlining', but it was worth it under various tests. It's up to you if you want to merge those.

All tests pass. If something needs to change, I'm willing to work on this.