### PR TITLE
New broadphase, tests and bug fixes

### DIFF
--- a/src/main/java/org/dyn4j/collision/broadphase/AbstractBroadphaseDetector.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/AbstractBroadphaseDetector.java
@@ -137,6 +137,24 @@ public abstract class AbstractBroadphaseDetector<E extends Collidable<T>, T exte
 		return false;
 	}
 	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable)
+	 */
+	@Override
+	public boolean contains(E collidable) {
+		int size = collidable.getFixtureCount();
+		
+		for (int i = 0; i < size; i++) {
+			T fixture = collidable.getFixture(i);
+			
+			if (!this.contains(collidable, fixture)) {
+				return false;
+			}
+		}
+		
+		return true;
+	}
+	
 	/**
 	 * Returns true if the ray and AABB intersect.
 	 * <p>

--- a/src/main/java/org/dyn4j/collision/broadphase/DynamicAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/DynamicAABBTree.java
@@ -194,21 +194,6 @@ public class DynamicAABBTree<E extends Collidable<T>, T extends Fixture> extends
 	}
 	
 	/* (non-Javadoc)
-	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable)
-	 */
-	@Override
-	public boolean contains(E collidable) {
-		int size = collidable.getFixtureCount();
-		boolean result = true;
-		for (int i = 0; i < size; i++) {
-			T fixture = collidable.getFixture(i);
-			BroadphaseKey key = BroadphaseKey.get(collidable, fixture);
-			result &= this.map.containsKey(key);
-		}
-		return result;
-	}
-	
-	/* (non-Javadoc)
 	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
 	 */
 	@Override

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
@@ -140,7 +140,6 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 		} else {
 			// add new node
 			LazyAABBTreeLeaf<E, T> node = new LazyAABBTreeLeaf<E, T>(collidable, fixture);
-			node.updateAABB();
 			
 			this.elementMap.put(key, node);
 			

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
@@ -240,24 +240,6 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	}
 	
 	/* (non-Javadoc)
-	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable)
-	 */
-	@Override
-	public boolean contains(E collidable) {
-		int size = collidable.getFixtureCount();
-		
-		for (int i = 0; i < size; i++) {
-			T fixture = collidable.getFixture(i);
-			
-			if (!this.contains(collidable, fixture)) {
-				return false;
-			}
-		}
-		
-		return true;
-	}
-	
-	/* (non-Javadoc)
 	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
 	 */
 	@Override

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
@@ -366,9 +366,6 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 			LazyAABBTreeLeaf<E, T> node = elements.get(i);
 			
 			if (!node.isOnTree()) {
-				// Mark that this leaf is now on the tree
-				node.setOnTree(true);
-				
 				insert(node);
 			}
 		}
@@ -461,6 +458,9 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	 * @param pairs List a list containing the results
 	 */
 	void insert(LazyAABBTreeLeaf<E, T> item, final boolean detect, BroadphaseFilter<E, T> filter, List<BroadphasePair<E, T>> pairs) {
+		// Mark that this leaf is now on the tree
+		item.setOnTree(true);
+		
 		// Make sure the root is not null
 		if (this.root == null) {
 			// If it is then set this node as the root

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeLeaf.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeLeaf.java
@@ -31,7 +31,7 @@ import org.dyn4j.geometry.Transform;
 /**
  * Represents a leaf node in a {@link LazyAABBTree}.
  * <p>
- * The leaf nodes in a {@link DynamicAABBTree2} are the nodes that contain the {@link Fixture} AABBs.
+ * The leaf nodes in a {@link LazyAABBTree} are the nodes that contain the {@link Fixture} AABBs.
  * 
  * @author Manolis Tsamis
  * @param <E> the {@link Collidable} type

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeLeaf.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeLeaf.java
@@ -60,6 +60,9 @@ final class LazyAABBTreeLeaf<E extends Collidable<T>, T extends Fixture> extends
 	public LazyAABBTreeLeaf(E collidable, T fixture) {
 		this.collidable = collidable;
 		this.fixture = fixture;
+		
+		// calculate the initial AABB
+		this.updateAABB();
 	}
 	
 	/**

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeLeaf.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeLeaf.java
@@ -143,7 +143,7 @@ final class LazyAABBTreeLeaf<E extends Collidable<T>, T extends Fixture> extends
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("DynamicAABBTreeLeaf[Collidable=").append(this.collidable.getId())
+		sb.append("LazyAABBTreeLeaf[Collidable=").append(this.collidable.getId())
 		  .append("|Fixture=").append(this.fixture.getId())
 		  .append("|AABB=").append(this.aabb.toString())
 		  .append("|OnTree=").append(this.onTree)

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeNode.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeNode.java
@@ -27,7 +27,7 @@ package org.dyn4j.collision.broadphase;
 import org.dyn4j.geometry.AABB;
 
 /**
- * Represents a basic node in a {@link DynamicAABBTree}.
+ * Represents a basic node in a {@link LazyAABBTree}.
  * <p>
  * The AABB of the node should be the union of all the AABBs below this node.
  * @author Manolis Tsamis

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeNode.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeNode.java
@@ -84,7 +84,7 @@ class LazyAABBTreeNode {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("DynamicAABBTreeNode[AABB=").append(this.aabb.toString())
+		sb.append("LazyAABBTreeNode[AABB=").append(this.aabb.toString())
 		  .append("|Height=").append(this.height)
 		  .append("]");
 		return sb.toString();

--- a/src/main/java/org/dyn4j/collision/broadphase/PlainBroadphase.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/PlainBroadphase.java
@@ -122,21 +122,6 @@ public class PlainBroadphase<E extends Collidable<T>, T extends Fixture> extends
 	}
 	
 	/* (non-Javadoc)
-	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable)
-	 */
-	@Override
-	public boolean contains(E collidable) {
-		int size = collidable.getFixtureCount();
-		boolean result = true;
-		for (int i = 0; i < size; i++) {
-			T fixture = collidable.getFixture(i);
-			BroadphaseKey key = BroadphaseKey.get(collidable, fixture);
-			result &= this.map.containsKey(key);
-		}
-		return result;
-	}
-	
-	/* (non-Javadoc)
 	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
 	 */
 	@Override

--- a/src/main/java/org/dyn4j/collision/broadphase/PlainBroadphase.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/PlainBroadphase.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2010-2017 William Bittle  http://www.dyn4j.org/
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted 
+ * provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice, this list of conditions 
+ *     and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions 
+ *     and the following disclaimer in the documentation and/or other materials provided with the 
+ *     distribution.
+ *   * Neither the name of dyn4j nor the names of its contributors may be used to endorse or 
+ *     promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER 
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.dyn4j.collision.broadphase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.dyn4j.collision.Collidable;
+import org.dyn4j.collision.Collisions;
+import org.dyn4j.collision.Fixture;
+import org.dyn4j.geometry.AABB;
+import org.dyn4j.geometry.Ray;
+import org.dyn4j.geometry.Vector2;
+
+/**
+ * This class implements the simplest possible broad-phase detector,
+ * a brute-force algorithm for finding all pairs of collisions (and similar queries).
+ * <p>
+ * This implementation is not tuned for performance in any way and should <b>not</b> be used
+ * except for testing purposes. One main reason this was developed is for automated testing of the other broad-phase detectors.
+ * <p>
+ * The logic of this class is simple: It holds a hash table of all the nodes and each time a query is made it scans linearly
+ * all the nodes to find the answer.
+ * <p>
+ * Important note: This class must not use AABB expansion in order to always return the minimum set of pairs/items.
+ * This property is used to test the other broad-phase detectors correctly.
+ * 
+ * @author Manolis Tsamis
+ * @version 3.3.1
+ * @since 3.3.1
+ * @param <E> the {@link Collidable} type
+ * @param <T> the {@link Fixture} type
+ */
+public class PlainBroadphase<E extends Collidable<T>, T extends Fixture> extends AbstractBroadphaseDetector<E, T> implements BroadphaseDetector<E, T> {
+	
+	/** Id to node map for fast lookup */
+	final Map<BroadphaseKey, PlainBroadphaseNode<E, T>> map;
+	
+	/**
+	 * Default constructor.
+	 */
+	public PlainBroadphase() {
+		this.map = new LinkedHashMap<BroadphaseKey, PlainBroadphaseNode<E,T>>();
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#add(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
+	 */
+	@Override
+	public void add(E collidable, T fixture) {
+		BroadphaseKey key = BroadphaseKey.get(collidable, fixture);
+		PlainBroadphaseNode<E, T> node = this.map.get(key);
+		
+		if (node != null) {
+			// if the collidable-fixture has already been added just update it
+			node.updateAABB();
+		} else {
+			// else add the new node
+			this.map.put(key, new PlainBroadphaseNode<E, T>(collidable, fixture));
+		}
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#remove(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
+	 */
+	@Override
+	public boolean remove(E collidable, T fixture) {
+		BroadphaseKey key = BroadphaseKey.get(collidable, fixture);
+		// find the node in the map
+		PlainBroadphaseNode<E, T> node = this.map.remove(key);
+		
+		return node != null;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#update(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
+	 */
+	@Override
+	public void update(E collidable, T fixture) {
+		add(collidable, fixture);
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#getAABB(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
+	 */
+	@Override
+	public AABB getAABB(E collidable, T fixture) {
+		BroadphaseKey key = BroadphaseKey.get(collidable, fixture);
+		PlainBroadphaseNode<E, T> node = this.map.get(key);
+		
+		if (node != null) {
+			return node.aabb;
+		}
+		
+		return fixture.getShape().createAABB(collidable.getTransform());
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable)
+	 */
+	@Override
+	public boolean contains(E collidable) {
+		int size = collidable.getFixtureCount();
+		boolean result = true;
+		for (int i = 0; i < size; i++) {
+			T fixture = collidable.getFixture(i);
+			BroadphaseKey key = BroadphaseKey.get(collidable, fixture);
+			result &= this.map.containsKey(key);
+		}
+		return result;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
+	 */
+	@Override
+	public boolean contains(E collidable, T fixture) {
+		BroadphaseKey key = BroadphaseKey.get(collidable, fixture);
+		return this.map.containsKey(key);
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#clear()
+	 */
+	@Override
+	public void clear() {
+		this.map.clear();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#size()
+	 */
+	@Override
+	public int size() {
+		return this.map.size();
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#detect(org.dyn4j.collision.broadphase.BroadphaseFilter)
+	 */
+	@Override
+	public List<BroadphasePair<E, T>> detect(BroadphaseFilter<E, T> filter) {
+		// clear all the tested flags on the nodes
+		int size = this.map.size();
+		Collection<PlainBroadphaseNode<E, T>> nodes = this.map.values();
+		for (PlainBroadphaseNode<E, T> node : nodes) {
+			// reset the flag
+			node.tested = false;
+		}
+		
+		// the estimated size of the pair list
+		int eSize = Collisions.getEstimatedCollisionPairs(size);
+		List<BroadphasePair<E, T>> pairs = new ArrayList<BroadphasePair<E, T>>(eSize);
+		
+		// test each collidable in the collection
+		for (PlainBroadphaseNode<E, T> node : nodes) {
+			for (PlainBroadphaseNode<E, T> other : nodes) {
+				if (node.aabb.overlaps(other.aabb) && !other.tested && other.collidable != node.collidable) {
+					// if they overlap and not already tested
+					if (filter.isAllowed(node.collidable, node.fixture, other.collidable, other.fixture)) {
+						BroadphasePair<E, T> pair = new BroadphasePair<E, T>(
+								node.collidable,	// A
+								node.fixture,
+								other.collidable,	// B
+								other.fixture);	
+						
+						// add the pair to the list of pairs
+						pairs.add(pair);
+					}
+				}
+			}
+			
+			// update the tested flag
+			node.tested = true;
+		}
+		
+		// return the list of pairs
+		return pairs;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#detect(org.dyn4j.geometry.AABB)
+	 */
+	@Override
+	public List<BroadphaseItem<E, T>> detect(AABB aabb, BroadphaseFilter<E, T> filter) {
+		// the estimated size of the item list
+		int eSize = Collisions.getEstimatedCollisionsPerObject();
+		List<BroadphaseItem<E, T>> list = new ArrayList<BroadphaseItem<E, T>>(eSize);
+		Collection<PlainBroadphaseNode<E, T>> nodes = this.map.values();
+		
+		// test each collidable in the collection
+		for (PlainBroadphaseNode<E, T> node : nodes) {
+			if (aabb.overlaps(node.aabb)) {
+				if (filter.isAllowed(aabb, node.collidable, node.fixture)) {
+					list.add(new BroadphaseItem<E, T>(node.collidable, node.fixture));
+				}
+			}
+		}
+		
+		return list;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#raycast(org.dyn4j.geometry.Ray, double)
+	 */
+	@Override
+	public List<BroadphaseItem<E, T>> raycast(Ray ray, double length, BroadphaseFilter<E, T> filter) {
+		// check the size of the proxy list
+		if (this.map.size() == 0) {
+			// return an empty list
+			return Collections.emptyList();
+		}
+		
+		// create an aabb from the ray
+		Vector2 s = ray.getStart();
+		Vector2 d = ray.getDirectionVector();
+		
+		// get the length
+		double l = length;
+		if (length <= 0.0) l = Double.MAX_VALUE;
+		
+		// compute the coordinates
+		double x1 = s.x;
+		double x2 = s.x + d.x * l;
+		double y1 = s.y;
+		double y2 = s.y + d.y * l;
+		
+		// create the aabb
+		AABB aabb = AABB.createAABBFromPoints(x1, y1, x2, y2);
+		
+		// precompute
+		double invDx = 1.0 / d.x;
+		double invDy = 1.0 / d.y;
+		
+		// get the estimated collision count
+		int eSize = Collisions.getEstimatedRaycastCollisions(this.map.size());
+		List<BroadphaseItem<E, T>> list = new ArrayList<BroadphaseItem<E, T>>(eSize);
+		Collection<PlainBroadphaseNode<E, T>> nodes = this.map.values();
+		
+		for (PlainBroadphaseNode<E, T> node : nodes) {
+			if (aabb.overlaps(node.aabb) && this.raycast(s, l, invDx, invDy, node.aabb)) {
+				if (filter.isAllowed(ray, length, node.collidable, node.fixture)) {
+					list.add(new BroadphaseItem<E, T>(node.collidable, node.fixture));
+				}
+			}
+		}
+		
+		return list;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.dyn4j.geometry.Shiftable#shift(org.dyn4j.geometry.Vector2)
+	 */
+	@Override
+	public void shift(Vector2 shift) {
+		Collection<PlainBroadphaseNode<E, T>> nodes = this.map.values();
+		
+		for (PlainBroadphaseNode<E, T> node : nodes) {
+			node.aabb.translate(shift);
+		}
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#getAABBExpansion()
+	 */
+	@Override
+	public double getAABBExpansion() {
+		return 0;
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#supportsAABBExpansion()
+	 */
+	@Override
+	public boolean supportsAABBExpansion() {
+		return false;
+	}
+}

--- a/src/main/java/org/dyn4j/collision/broadphase/PlainBroadphaseNode.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/PlainBroadphaseNode.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2016 William Bittle  http://www.dyn4j.org/
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted 
+ * provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice, this list of conditions 
+ *     and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions 
+ *     and the following disclaimer in the documentation and/or other materials provided with the 
+ *     distribution.
+ *   * Neither the name of dyn4j nor the names of its contributors may be used to endorse or 
+ *     promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER 
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.dyn4j.collision.broadphase;
+
+import org.dyn4j.collision.Collidable;
+import org.dyn4j.collision.Fixture;
+import org.dyn4j.geometry.AABB;
+import org.dyn4j.geometry.Transform;
+
+/**
+ * Simple helper class that holds information for each item in the {@link PlainBroadphase}.
+ * 
+ * @author Manolis Tsamis
+ * @version 3.3.1
+ * @since 3.3.1
+ * @param <E> the {@link Collidable} type
+ * @param <T> the {@link Fixture} type
+ */
+class PlainBroadphaseNode<E extends Collidable<T>, T extends Fixture> {
+	public final E collidable;
+	public final T fixture;
+	public AABB aabb;
+	boolean tested;
+
+	PlainBroadphaseNode(E collidable, T fixture) {
+		this.collidable = collidable;
+		this.fixture = fixture;
+		
+		// calculate the initial AABB
+		updateAABB();
+	}
+	
+	/**
+	 * Updates the AABB of this node
+	 */
+	void updateAABB() {
+		// Remember, we don't expand the AABB
+		Transform tx = collidable.getTransform();
+		this.aabb = fixture.getShape().createAABB(tx);
+	}
+	
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("PlainBroadphaseNode[AABB=").append(this.aabb.toString())
+		.append("|Fixture=").append(this.fixture.getId())
+		.append("]");
+		return sb.toString();
+	}
+}

--- a/src/main/java/org/dyn4j/collision/broadphase/PlainBroadphaseNode.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/PlainBroadphaseNode.java
@@ -49,7 +49,7 @@ class PlainBroadphaseNode<E extends Collidable<T>, T extends Fixture> {
 		this.fixture = fixture;
 		
 		// calculate the initial AABB
-		updateAABB();
+		this.updateAABB();
 	}
 	
 	/**

--- a/src/main/java/org/dyn4j/collision/broadphase/Sap.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/Sap.java
@@ -191,21 +191,6 @@ public class Sap<E extends Collidable<T>, T extends Fixture> extends AbstractBro
 	}
 	
 	/* (non-Javadoc)
-	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable)
-	 */
-	@Override
-	public boolean contains(E collidable) {
-		int size = collidable.getFixtureCount();
-		boolean result = true;
-		for (int i = 0; i < size; i++) {
-			T fixture = collidable.getFixture(i);
-			BroadphaseKey key = BroadphaseKey.get(collidable, fixture);
-			result &= this.map.containsKey(key);
-		}
-		return result;
-	}
-	
-	/* (non-Javadoc)
 	 * @see org.dyn4j.collision.broadphase.BroadphaseDetector#contains(org.dyn4j.collision.Collidable, org.dyn4j.collision.Fixture)
 	 */
 	@Override

--- a/src/test/java/org/dyn4j/collision/BroadphaseTest.java
+++ b/src/test/java/org/dyn4j/collision/BroadphaseTest.java
@@ -591,32 +591,23 @@ public class BroadphaseTest {
 		}
 	}
 	
+	/**
+	 * Simple helper method that finds if a {@link BroadphasePair} or it's reverse pair is
+	 * contained in a list of {@link BroadphasePair}s.
+	 * 
+	 * @param pair The pair to search
+	 * @param pairs The list of pairs
+	 * @return true if pair or it's reverse is contained in the list, false otherwise
+	 */
 	private boolean pairExists(BroadphasePair<CollidableTest, Fixture> pair, List<BroadphasePair<CollidableTest, Fixture>> pairs) {
-		for (BroadphasePair<CollidableTest, Fixture> p : pairs) {
-			boolean equal = false;
+		if (pairs.contains(pair)) {
+			return true;
+		} else {
+			BroadphasePair<CollidableTest, Fixture> reversePair = new BroadphasePair<CollidableTest, Fixture>(
+					pair.getCollidable2(), pair.getFixture2(), pair.getCollidable1(), pair.getFixture1());
 			
-			if (p.getCollidable1() == pair.getCollidable1() &&
-				p.getFixture1() == pair.getFixture1() &&
-				p.getCollidable2() == pair.getCollidable2() &&
-				p.getFixture2() == pair.getFixture2()) {
-				
-				equal =  true;
-			}
-			
-			if (p.getCollidable2() == pair.getCollidable1() &&
-				p.getFixture2() == pair.getFixture1() &&
-				p.getCollidable1() == pair.getCollidable2() &&
-				p.getFixture1() == pair.getFixture2()) {
-				
-				equal =  true;
-			}
-			
-			if (equal) {
-				return true;
-			}
+			return pairs.contains(reversePair);
 		}
-		
-		return false;
 	}
 	
 }


### PR DESCRIPTION
As promised, this pull requests introduces a new 'brute-force' broad-phase detector. The focus of this PR is the PlainBroadphase (the new broad-phase) and the randomized test I talked about. The other commits are small changes and a bug fix for the previous LazyAABBTree.
The code of PlainBroadphase is quite easy to understand, so I won't make much comments on it.

The randomized test incrementally creates random objects and performs random queries with each existing broadphase detector and compares the result with the PlainBroadphase. Of course the PRNG is seeded with a constant so each time the exact same test is ran, since nobody wants non-deterministic unit tests.

I actually found 2 bugs with this new test, one in LazyAABBTree and one in the SAP broad-phase. 

- LazyAABBTree would under conditions enter an infinite loop when raycasting, because setOnTree was not called in the buildAndDetect method. I made a change and fixed this.

- SAP for some reason gives some wrong answers for detect(AABB), that is returns a list with some missing items. I have not found the exact cause, but I suspect there is indeed a bug in it. If you run the new BroadphaseTest you will see SAP failing the randomized test with 'detect(AABB) is missing items'.

I didn't look into SAP yet, but I thought it was a good time to make this PR.