### PR TITLE
Minor LazyAABBTree improvements

### DIFF
--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
@@ -303,12 +303,14 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 					if (this.elements.size() == 1) {
 						this.elements.remove(0);
 					} else {
+						int lastIndex = this.elements.size() - 1;
+						
 						// Swap with the last
-						this.elements.set(i, elements.get(elements.size() - 1));
+						this.elements.set(i, this.elements.get(lastIndex));
 						
 						// And remove the last
 						// No copying involved here, just a size decrease
-						this.elements.remove(elements.size() - 1);
+						this.elements.remove(lastIndex);
 						
 						i--;
 					}
@@ -329,7 +331,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	 */
 	void ensureSorted() {
 		if (!this.sorted) {
-			Collections.sort(elements, new Comparator<LazyAABBTreeLeaf<E, T>>() {
+			Collections.sort(this.elements, new Comparator<LazyAABBTreeLeaf<E, T>>() {
 				@Override
 				public int compare(LazyAABBTreeLeaf<E, T> o1, LazyAABBTreeLeaf<E, T> o2) {
 					// Important heuristic: sort by size of fixtures.
@@ -362,7 +364,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 		this.ensureSorted();
 		
 		for (int i = 0; i < this.elements.size(); i++) {
-			LazyAABBTreeLeaf<E, T> node = elements.get(i);
+			LazyAABBTreeLeaf<E, T> node = this.elements.get(i);
 			
 			if (!node.isOnTree()) {
 				this.insert(node);
@@ -382,7 +384,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 		this.ensureSorted();
 		
 		for (int i = 0; i < this.elements.size(); i++) {
-			LazyAABBTreeLeaf<E, T> node = elements.get(i);
+			LazyAABBTreeLeaf<E, T> node = this.elements.get(i);
 			
 			this.insertAndDetect(node, filter, pairs);
 		}
@@ -468,7 +470,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 		// loop until node is a leaf
 		while (!node.isLeaf()) {
 			LazyAABBTreeNode other;
-			double costLeft = descendCost(node.left, itemAABB);
+			double costLeft = this.descendCost(node.left, itemAABB);
 			
 			if (costLeft == 0) {
 				// Fast path: if (costLeft == 0) then this means that
@@ -482,7 +484,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 				other = node.right;
 				node = node.left;
 			} else {
-				double costRight = descendCost(node.right, itemAABB);
+				double costRight = this.descendCost(node.right, itemAABB);
 				// Although we could check if (costRight == 0) and make a similar case as above
 				// there are not many gains, one fast path is enough
 				

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
@@ -388,45 +388,27 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 			insertAndDetect(node, filter, pairs);
 		}
 	}
-	
+
 	/**
-	 * The cost function for an AABB in the tree is it's perimeter.
-	 * We actually calculate half the perimeter to avoid one multiplication since the results don't change by doing this globally.
-	 * 
-	 * @param a an AABB
-	 * @return half it's perimeter, used as the cost in the tree
-	 */
-	double cost(AABB a) {
-		return a.getWidth() + a.getHeight();
-	}
-	
-	/**
-	 * Calculates cost(a.getUnion(b)) in a more efficient way
-	 * 
-	 * @param a the first AABB
-	 * @param b the second AABB
-	 * @return the cost function applied to their union
-	 */
-	double costOfUnion(AABB a, AABB b) {
-		double unionWidth = Math.max(a.getMaxX(), b.getMaxX()) - Math.min(a.getMinX(), b.getMinX());
-		double unionHeight = Math.max(a.getMaxY(), b.getMaxY()) - Math.min(a.getMinY(), b.getMinY());
-		
-		return unionWidth + unionHeight;
-	}
-	
-	/**
-	 * Taken from the original {@link DynamicAABBTree}
+	 * Cost function for descending to a particular node.
+	 * The cost equals the enlargement caused in the {@link AABB} of the node.
 	 * 
 	 * @param node the node to descend
 	 * @param itemAABB the AABB of the item being inserted
 	 * @return the cost of descending to node
 	 */
 	double descendCost(LazyAABBTreeNode node, AABB itemAABB) {
-		if (node.isLeaf()) {
-			return costOfUnion(node.aabb, itemAABB);
-		} else {
-			return costOfUnion(node.aabb, itemAABB) - cost(node.aabb);
-		}
+		AABB nodeAABB = node.aabb;
+		
+		// Calculate enlargement in x axis
+		double enlargementMinX = Math.max(nodeAABB.getMinX() - itemAABB.getMinX(), 0);
+		double enlargementMaxX = Math.max(itemAABB.getMaxX() - nodeAABB.getMaxX(), 0);
+		
+		// Calculate enlargement in y axis
+		double enlargementMinY = Math.max(nodeAABB.getMinY() - itemAABB.getMinY(), 0);
+		double enlargementMaxY = Math.max(itemAABB.getMaxY() - nodeAABB.getMaxY(), 0);
+		
+		return enlargementMinX + enlargementMaxX + enlargementMinY + enlargementMaxY;
 	}
 	
 	/**

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
@@ -400,15 +400,24 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	double descendCost(LazyAABBTreeNode node, AABB itemAABB) {
 		AABB nodeAABB = node.aabb;
 		
+		// The positive values indicate enlargement
+		double enlargement = 0;
+		
 		// Calculate enlargement in x axis
-		double enlargementMinX = Math.max(nodeAABB.getMinX() - itemAABB.getMinX(), 0);
-		double enlargementMaxX = Math.max(itemAABB.getMaxX() - nodeAABB.getMaxX(), 0);
+		double enlargementMinX = nodeAABB.getMinX() - itemAABB.getMinX();
+		double enlargementMaxX = itemAABB.getMaxX() - nodeAABB.getMaxX();
+		
+		if (enlargementMinX > 0) enlargement += enlargementMinX;
+		if (enlargementMaxX > 0) enlargement += enlargementMaxX; 
 		
 		// Calculate enlargement in y axis
-		double enlargementMinY = Math.max(nodeAABB.getMinY() - itemAABB.getMinY(), 0);
-		double enlargementMaxY = Math.max(itemAABB.getMaxY() - nodeAABB.getMaxY(), 0);
+		double enlargementMinY = nodeAABB.getMinY() - itemAABB.getMinY();
+		double enlargementMaxY = itemAABB.getMaxY() - nodeAABB.getMaxY();
 		
-		return enlargementMinX + enlargementMaxX + enlargementMinY + enlargementMaxY;
+		if (enlargementMinY > 0) enlargement += enlargementMinY;
+		if (enlargementMaxY > 0) enlargement += enlargementMaxY;
+		
+		return enlargement;
 	}
 	
 	/**

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
@@ -48,7 +48,6 @@ import org.dyn4j.geometry.Vector2;
  * Insertion is O(1), update is O(logn) but batch update (update of all bodies) is O(n), remove is O(logn) average but O(n) worse.
  * <p>
  * The class will rebuild the whole tree at each detection and will detect the collisions at the same time in an efficient manner.
- * The cost function and balancing are the same as in {@link DynamicAABBTree}.
  * <p>
  * This structure keeps the bodies sorted by the radius of their fixtures and rebuilds the tree each time in order to construct better trees.
  * 
@@ -392,6 +391,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	/**
 	 * Cost function for descending to a particular node.
 	 * The cost equals the enlargement caused in the {@link AABB} of the node.
+	 * More specifically, descendCost(node, aabb) = (perimeter(union(node.aabb, aabb)) - perimeter(node.aabb)) / 2
 	 * 
 	 * @param node the node to descend
 	 * @param itemAABB the AABB of the item being inserted
@@ -456,7 +456,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 		// Start looking for the insertion point at the root
 		LazyAABBTreeNode node = this.root;
 		
-		// loop until node is a leaf or we find a better location
+		// loop until node is a leaf
 		while (!node.isLeaf()) {
 			LazyAABBTreeNode other;
 			double costLeft = descendCost(node.left, itemAABB);

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTree.java
@@ -166,7 +166,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 			}
 			
 			node.markForRemoval();
-			pendingRemoves = true;
+			this.pendingRemoves = true;
 			
 			return true;
 		}
@@ -204,7 +204,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 			other.parent = grandparent;
 			
 			// finally rebalance the tree
-			balanceAll(grandparent);
+			this.balanceAll(grandparent);
 		} else {
 			// the parent is the root so set the root to the sibling
 			this.root = other;
@@ -220,7 +220,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	public void update(E collidable, T fixture) {
 		// In the way the add and update are described in BroadphaseDetector, their functionallity is identical
 		// so just redirect the work to add for less duplication.
-		add(collidable, fixture);
+		this.add(collidable, fixture);
 	}
 	
 	/* (non-Javadoc)
@@ -276,10 +276,10 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 		// this will not happen, unless the user makes more detect calls outside of the World class
 		// so it can be considered rare
 		if (this.root != null) {
-			batchRebuild();
+			this.batchRebuild();
 		}
 		
-		buildAndDetect(filter, pairs);
+		this.buildAndDetect(filter, pairs);
 		
 		return pairs;
 	}
@@ -304,11 +304,11 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 						this.elements.remove(0);
 					} else {
 						// Swap with the last
-						elements.set(i, elements.get(elements.size() - 1));
+						this.elements.set(i, elements.get(elements.size() - 1));
 						
 						// And remove the last
 						// No copying involved here, just a size decrease
-						elements.remove(elements.size() - 1);
+						this.elements.remove(elements.size() - 1);
 						
 						i--;
 					}
@@ -358,14 +358,14 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	 * This is used to support raycasting and single AABB queries.
 	 */
 	void build() {
-		doPendingRemoves();
-		ensureSorted();
+		this.doPendingRemoves();
+		this.ensureSorted();
 		
 		for (int i = 0; i < this.elements.size(); i++) {
 			LazyAABBTreeLeaf<E, T> node = elements.get(i);
 			
 			if (!node.isOnTree()) {
-				insert(node);
+				this.insert(node);
 			}
 		}
 	}
@@ -378,13 +378,13 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	 * @param pairs List a list containing the results
 	 */
 	void buildAndDetect(BroadphaseFilter<E, T> filter, List<BroadphasePair<E, T>> pairs) {
-		doPendingRemoves();
-		ensureSorted();
+		this.doPendingRemoves();
+		this.ensureSorted();
 		
 		for (int i = 0; i < this.elements.size(); i++) {
 			LazyAABBTreeLeaf<E, T> node = elements.get(i);
 			
-			insertAndDetect(node, filter, pairs);
+			this.insertAndDetect(node, filter, pairs);
 		}
 	}
 
@@ -500,13 +500,13 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 			
 			// perform collision detection to the child that we did not descend if needed
 			if (detect && other.aabb.overlaps(itemAABB)) {
-				detectWhileBuilding(item, other, filter, pairs);	
+				this.detectWhileBuilding(item, other, filter, pairs);	
 			}
 		}
 		
 		// We also need to perform collision detection for the leaf where we ended
 		if (detect && node.aabb.overlaps(itemAABB)) {
-			detectWhileBuilding(item, node, filter, pairs);	
+			this.detectWhileBuilding(item, node, filter, pairs);	
 		}
 		
 		// Now that we have found a suitable place, insert a new node here for the new item
@@ -532,7 +532,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 		item.parent = newParent;
 		
 		// Fix the heights and balance the tree
-		balanceAll(newParent.parent);
+		this.balanceAll(newParent.parent);
 	}
 	
 	/**
@@ -560,8 +560,8 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 			}
 		} else {
 			// they overlap so descend into both children
-			if (node.aabb.overlaps(root.left.aabb)) detectWhileBuilding(node, root.left, filter, pairs);
-			if (node.aabb.overlaps(root.right.aabb)) detectWhileBuilding(node, root.right, filter, pairs);
+			if (node.aabb.overlaps(root.left.aabb)) this.detectWhileBuilding(node, root.left, filter, pairs);
+			if (node.aabb.overlaps(root.right.aabb)) this.detectWhileBuilding(node, root.right, filter, pairs);
 		}
 	}
 	
@@ -570,7 +570,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	 */
 	@Override
 	public List<BroadphaseItem<E, T>> detect(AABB aabb, BroadphaseFilter<E, T> filter) {
-		build();
+		this.build();
 		
 		if (this.root == null) {
 			return Collections.emptyList();
@@ -618,7 +618,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	 */
 	@Override
 	public List<BroadphaseItem<E, T>> raycast(Ray ray, double length, BroadphaseFilter<E, T> filter) {
-		build();
+		this.build();
 		
 		if (this.root == null) {
 			return Collections.emptyList();
@@ -753,7 +753,7 @@ public class LazyAABBTree<E extends Collidable<T>, T extends Fixture> extends Ab
 	void balanceAll(LazyAABBTreeNode node) {
 		while (node != null) {
 			// balance the current tree
-			balance(node);
+			this.balance(node);
 			node = node.parent;
 		}
 	}

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeNode.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeNode.java
@@ -49,24 +49,39 @@ class LazyAABBTreeNode {
 	
 	/** The aabb containing all children */
 	public AABB aabb;
-
+	
+	/**
+	 * Replace oldChild with newChild. oldChild must be a child of this node before the replacement.
+	 * Children are compared with the equality operator.
+	 * 
+	 * @param oldChild The child to replace in this node
+	 * @param newChild The replacement
+	 * @throws IllegalArgumentException if oldChild is not a child of this node
+	 */
 	public void replaceChild(LazyAABBTreeNode oldChild, LazyAABBTreeNode newChild) {
 		if (left == oldChild) {
 			left = newChild;
 		} else if (right == oldChild) {
 			right = newChild;
 		} else {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(oldChild.toString() + " is not a child of node " + this.toString());
 		}
 	}
 	
+	/**
+	 * Returns the sibling of this node, that is the other child of this node's parent.
+	 * 
+	 * @return The sibling node
+	 * @throws NullPointerException if this node has no parent
+	 * @throws IllegalStateException if this node is not a child of it's parent
+	 */
 	public LazyAABBTreeNode getSibling() {
 		if (parent.left == this) {
 			return parent.right;
 		} else if (parent.right == this) {
 			return parent.left;
 		} else {
-			throw new IllegalArgumentException();
+			throw new IllegalStateException("Invalid parent pointer for node " + this.toString());
 		}
 	}
 	


### PR DESCRIPTION
Small PR to merge some improvements and cleanups to LazyAABBTree.

- A slightly modified cost functions for descending the tree (enlargement amount), same for inner and leaf nodes
- New inserted nodes always go to the leafs; No checks for adding a node somewhere in between. This is because when bodies are sorted by size (as in LazyAABBTree) the cost of inserting higher in the tree is almost always so big that it is better to go lower. So that heuristic didn't alter a lot the structure of the tree, but added an additional cost for checking and comparing all the cases. I think it also helps to have a better balanced tree.
- A 'fast path' for descending faster to some side (left); The current cost heuristic allows us to know for free if a node is contained entirely in another while descending. Because as the tree grows it is very likely for a new AABB to be contained in either left/right child for the top tree levels, this special check allows to dive into the tree faster in some cases.

Those are overall minor changes and don't alter much the structure of this broad-phase, but overall  give a small performance boost (depending on the workload).
And those changes probably conclude the LazyAABBTree detector, I don't think there's anything left to tweak for this specific one.

Also now that I'm finished with this one, I really suggest we change the default broad-phase to be this for the next release. Compared to the current default it is way faster in all cases.
