### PR TITLE
Deprecate the UUID scheme (#47)

### DIFF
--- a/src/main/java/org/dyn4j/collision/AbstractCollidable.java
+++ b/src/main/java/org/dyn4j/collision/AbstractCollidable.java
@@ -86,14 +86,6 @@ public abstract class AbstractCollidable<T extends Fixture> implements Collidabl
 	}
 	
 	/* (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode() {
-		return this.id.hashCode();
-	}
-	
-	/* (non-Javadoc)
 	 * @see org.dyn4j.collision.Collidable#removeFixture(org.dyn4j.collision.Fixture)
 	 */
 	public boolean removeFixture(T fixture) {

--- a/src/main/java/org/dyn4j/collision/AbstractCollidable.java
+++ b/src/main/java/org/dyn4j/collision/AbstractCollidable.java
@@ -342,6 +342,7 @@ public abstract class AbstractCollidable<T extends Fixture> implements Collidabl
 	/* (non-Javadoc)
 	 * @see org.dyn4j.collision.Collidable#getId()
 	 */
+	@Deprecated(forRemoval = true)
 	public UUID getId() {
 		return this.id;
 	}

--- a/src/main/java/org/dyn4j/collision/AbstractCollidable.java
+++ b/src/main/java/org/dyn4j/collision/AbstractCollidable.java
@@ -86,19 +86,6 @@ public abstract class AbstractCollidable<T extends Fixture> implements Collidabl
 	}
 	
 	/* (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == null) return false;
-		if (obj == this) return true;
-		if (obj instanceof AbstractCollidable) {
-			return this.id.equals(((AbstractCollidable<?>)obj).id);
-		}
-		return false;
-	}
-	
-	/* (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
 	 */
 	@Override

--- a/src/main/java/org/dyn4j/collision/Collidable.java
+++ b/src/main/java/org/dyn4j/collision/Collidable.java
@@ -53,9 +53,11 @@ public interface Collidable<T extends Fixture> extends Transformable, Shiftable,
 	 * Returns a unique identifier for this {@link Collidable}.
 	 * <p>
 	 * This identifier is constant for the life of this {@link Collidable}.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return UUID the unique id
 	 * @since 3.0.0
 	 */
+	@Deprecated(forRemoval = true)
 	public abstract UUID getId();
 	
 	/**

--- a/src/main/java/org/dyn4j/collision/Fixture.java
+++ b/src/main/java/org/dyn4j/collision/Fixture.java
@@ -89,14 +89,6 @@ public class Fixture implements DataContainer {
 	}
 	
 	/* (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode() {
-		return this.id.hashCode();
-	}
-	
-	/* (non-Javadoc)
 	 * @see java.lang.Object#toString()
 	 */
 	@Override

--- a/src/main/java/org/dyn4j/collision/Fixture.java
+++ b/src/main/java/org/dyn4j/collision/Fixture.java
@@ -106,8 +106,10 @@ public class Fixture implements DataContainer {
 	 * Returns the id for this fixture.
 	 * <p>
 	 * This identifier is constant for the life of this {@link Fixture}.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return UUID
 	 */
+	@Deprecated(forRemoval = true)
 	public UUID getId() {
 		return this.id;
 	}

--- a/src/main/java/org/dyn4j/collision/Fixture.java
+++ b/src/main/java/org/dyn4j/collision/Fixture.java
@@ -89,19 +89,6 @@ public class Fixture implements DataContainer {
 	}
 	
 	/* (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == null) return false;
-		if (obj == this) return true;
-		if (obj instanceof Fixture) {
-			return this.id.equals(((Fixture)obj).id);
-		}
-		return false;
-	}
-	
-	/* (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
 	 */
 	@Override

--- a/src/main/java/org/dyn4j/collision/broadphase/BroadphaseItem.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/BroadphaseItem.java
@@ -78,8 +78,8 @@ public final class BroadphaseItem<E extends Collidable<T>, T extends Fixture> {
 	@Override
 	public int hashCode() {
 		int hash = 17;
-		hash = hash * 31 + this.collidable.getId().hashCode();
-		hash = hash * 31 + this.fixture.getId().hashCode();
+		hash = hash * 31 + this.collidable.hashCode();
+		hash = hash * 31 + this.fixture.hashCode();
 		return hash;
 	}
 	

--- a/src/main/java/org/dyn4j/collision/broadphase/BroadphaseKey.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/BroadphaseKey.java
@@ -31,14 +31,14 @@ import org.dyn4j.collision.Fixture;
  * Represents a key for a {@link BroadphaseItem} used for fast look ups in
  * the {@link BroadphaseDetector}s.
  * @author William Bittle
- * @version 3.2.0
+ * @version 3.3.1
  * @since 3.2.0
  */
 final class BroadphaseKey {
-	/** The {@link Collidable}s id */
+	/** The {@link Collidable} */
 	final Collidable<?> collidable;
 	
-	/** The {@link Fixture}s id */
+	/** The {@link Fixture} */
 	final Fixture fixture;
 	
 	/** The pre-computed hashcode */
@@ -46,8 +46,8 @@ final class BroadphaseKey {
 	
 	/**
 	 * Minimal constructor.
-	 * @param collidable the collidable id
-	 * @param fixture the fixture id
+	 * @param collidable the {@link Collidable}
+	 * @param fixture the {@link Fixture}
 	 */
 	public BroadphaseKey(Collidable<?> collidable, Fixture fixture) {
 		this.collidable = collidable;
@@ -58,8 +58,8 @@ final class BroadphaseKey {
 	
 	/**
 	 * Creates and returns a new key for the given {@link Collidable} and {@link Fixture}.
-	 * @param collidable the collidable
-	 * @param fixture the fixture
+	 * @param collidable the {@link Collidable}
+	 * @param fixture the {@link Fixture}
 	 * @return {@link BroadphaseKey}
 	 */
 	public static final BroadphaseKey get(Collidable<?> collidable, Fixture fixture) {
@@ -106,8 +106,8 @@ final class BroadphaseKey {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("BroadphaseKey[CollidableId=").append(this.collidable)
-		.append("|FixtureId=").append(this.fixture)
+		sb.append("BroadphaseKey[Collidable=").append(this.collidable.getId())
+		.append("|Fixture=").append(this.fixture.getId())
 		.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/dyn4j/collision/broadphase/BroadphaseKey.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/BroadphaseKey.java
@@ -24,8 +24,6 @@
  */
 package org.dyn4j.collision.broadphase;
 
-import java.util.UUID;
-
 import org.dyn4j.collision.Collidable;
 import org.dyn4j.collision.Fixture;
 
@@ -38,10 +36,10 @@ import org.dyn4j.collision.Fixture;
  */
 final class BroadphaseKey {
 	/** The {@link Collidable}s id */
-	final UUID collidable;
+	final Collidable<?> collidable;
 	
 	/** The {@link Fixture}s id */
-	final UUID fixture;
+	final Fixture fixture;
 	
 	/** The pre-computed hashcode */
 	private final int hashCode;
@@ -51,7 +49,7 @@ final class BroadphaseKey {
 	 * @param collidable the collidable id
 	 * @param fixture the fixture id
 	 */
-	public BroadphaseKey(UUID collidable, UUID fixture) {
+	public BroadphaseKey(Collidable<?> collidable, Fixture fixture) {
 		this.collidable = collidable;
 		this.fixture = fixture;
 		// pre compute the hash
@@ -65,7 +63,7 @@ final class BroadphaseKey {
 	 * @return {@link BroadphaseKey}
 	 */
 	public static final BroadphaseKey get(Collidable<?> collidable, Fixture fixture) {
-		return new BroadphaseKey(collidable.getId(), fixture.getId());
+		return new BroadphaseKey(collidable, fixture);
 	}
 	
 	/* (non-Javadoc)
@@ -77,8 +75,8 @@ final class BroadphaseKey {
 		if (obj == this) return true;
 		if (obj instanceof BroadphaseKey) {
 			BroadphaseKey key = (BroadphaseKey)obj;
-			return key.collidable.equals(this.collidable) &&
-				   key.fixture.equals(this.fixture);
+			return key.collidable == this.collidable &&
+				   key.fixture == this.fixture;
 		}
 		return false;
 	}

--- a/src/main/java/org/dyn4j/collision/broadphase/SapProxy.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/SapProxy.java
@@ -34,7 +34,7 @@ import org.dyn4j.geometry.AABB;
  * Note: This class has a natural ordering that is inconsistent with equals.
  * @author William Bittle
  * @since 3.2.3
- * @version 3.2.0
+ * @version 3.3.1
  * @param <E> the {@link Collidable} type
  * @param <T> the {@link Fixture} type
  */
@@ -76,16 +76,7 @@ final class SapProxy<E extends Collidable<T>, T extends Fixture> implements Comp
 		} else {
 			// if the x values are the same then compare on the y values
 			diff = this.aabb.getMinY() - o.aabb.getMinY();
-			if (diff != 0) {
-				return (int)Math.signum(diff);
-			} else {
-				// finally if their y values are the same then compare on the ids
-				diff = this.collidable.getId().compareTo(o.collidable.getId());
-				if (diff == 0) {
-					return this.fixture.getId().compareTo(o.fixture.getId());
-				}
-				return (int)Math.signum(diff);
-			}
+			return (int)Math.signum(diff);
 		}
 	}
 

--- a/src/main/java/org/dyn4j/dynamics/World.java
+++ b/src/main/java/org/dyn4j/dynamics/World.java
@@ -3255,9 +3255,11 @@ public class World implements Shiftable, DataContainer {
 	
 	/**
 	 * Returns the world id.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return UUID
 	 * @since 3.2.0
 	 */
+	@Deprecated(forRemoval = true)
 	public UUID getId() {
 		return this.id;
 	}

--- a/src/main/java/org/dyn4j/dynamics/contact/ContactConstraintId.java
+++ b/src/main/java/org/dyn4j/dynamics/contact/ContactConstraintId.java
@@ -35,21 +35,21 @@ import org.dyn4j.geometry.Shape;
  * Represents and id for a contact constraint between two {@link Convex}
  * {@link Shape}s on two {@link Body}s.
  * @author William Bittle
- * @version 3.2.0
+ * @version 3.3.1
  * @since 1.0.0
  */
 public final class ContactConstraintId {
-	/** The first {@link Body}'s id */
-	private final UUID body1Id;
+	/** The first {@link Body} */
+	private final Body body1;
 	
-	/** The second {@link Body}'s id */
-	private final UUID body2Id;
+	/** The second {@link Body} */
+	private final Body body2;
 	
-	/** The first {@link Body}'s {@link Convex} {@link Shape} id */
-	private final UUID fixture1Id;
+	/** The first {@link Body}'s {@link Convex} {@link Shape} */
+	private final BodyFixture fixture1;
 	
-	/** The second {@link Body}'s {@link Convex} {@link Shape} id */
-	private final UUID fixture2Id;
+	/** The second {@link Body}'s {@link Convex} {@link Shape} */
+	private final BodyFixture fixture2;
 	
 	/**
 	 * Full constructor.
@@ -59,10 +59,10 @@ public final class ContactConstraintId {
 	 * @param fixture2 the second {@link Body}'s {@link BodyFixture}
 	 */
 	public ContactConstraintId(Body body1, BodyFixture fixture1, Body body2, BodyFixture fixture2) {
-		this.body1Id = body1.getId();
-		this.body2Id = body2.getId();
-		this.fixture1Id = fixture1.getId();
-		this.fixture2Id = fixture2.getId();
+		this.body1 = body1;
+		this.body2 = body2;
+		this.fixture1 = fixture1;
+		this.fixture2 = fixture2;
 	}
 	
 	/* (non-Javadoc)
@@ -74,11 +74,11 @@ public final class ContactConstraintId {
 		if (other == this) return true;
 		if (other instanceof ContactConstraintId) {
 			ContactConstraintId o = (ContactConstraintId) other;
-			if ((this.body1Id.equals(o.body1Id) && this.body2Id.equals(o.body2Id)
-			  && this.fixture1Id.equals(o.fixture1Id) && this.fixture2Id.equals(o.fixture2Id))
+			if ((this.body1 == o.body1 && this.body2 == o.body2
+			  && this.fixture1 == o.fixture1 && this.fixture2 == o.fixture2)
 			  // the order of the objects doesn't matter
-			 || (this.body1Id.equals(o.body2Id) && this.body2Id.equals(o.body1Id)
-			  && this.fixture1Id.equals(o.fixture2Id) && this.fixture2Id.equals(o.fixture1Id))) {
+			 || (this.body1 == o.body2 && this.body2 == o.body1
+			  && this.fixture1 == o.fixture2 && this.fixture2 == o.fixture1)) {
 				return true;
 			}
 		}
@@ -91,8 +91,8 @@ public final class ContactConstraintId {
 	@Override
 	public int hashCode() {
 		int hash = 1;
-		hash = hash * 31 + body1Id.hashCode() + body2Id.hashCode();
-		hash = hash * 31 + fixture1Id.hashCode() + fixture2Id.hashCode();
+		hash = hash * 31 + body1.hashCode() + body2.hashCode();
+		hash = hash * 31 + fixture1.hashCode() + fixture2.hashCode();
 		return hash;
 	}
 	
@@ -102,47 +102,83 @@ public final class ContactConstraintId {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("ContactConstraintId[Body1Id=").append(this.body1Id)
-		.append("|Body2Id=").append(this.body2Id)
-		.append("|Fixture1Id=").append(this.fixture1Id)
-		.append("|Fixture2Id=").append(this.fixture2Id)
+		sb.append("ContactConstraintId[Body1=").append(this.body1.getId())
+		.append("|Body2=").append(this.body2.getId())
+		.append("|Fixture1=").append(this.fixture1.getId())
+		.append("|Fixture2=").append(this.fixture2.getId())
 		.append("]");
 		return sb.toString();
 	}
-
+	
 	/**
 	 * Returns the id of the first body.
-	 * @return String
+	 * @return UUID
 	 * @since 3.1.2
 	 */
 	public UUID getBody1Id() {
-		return this.body1Id;
+		return this.body1.getId();
 	}
 
 	/**
 	 * Returns the id of the second body.
-	 * @return String
+	 * @return UUID
 	 * @since 3.1.2
 	 */
 	public UUID getBody2Id() {
-		return this.body2Id;
+		return this.body2.getId();
 	}
 
 	/**
 	 * Returns the id of the fixture on the first body.
-	 * @return String
+	 * @return UUID
 	 * @since 3.1.2
 	 */
 	public UUID getFixture1Id() {
-		return this.fixture1Id;
+		return this.fixture1.getId();
 	}
 
 	/**
 	 * Returns the id of the fixture on the second body.
-	 * @return String
+	 * @return UUID
 	 * @since 3.1.2
 	 */
 	public UUID getFixture2Id() {
-		return this.fixture2Id;
+		return this.fixture2.getId();
+	}
+	
+	/**
+	 * Returns the first body.
+	 * @return Body
+	 * @since 3.3.1
+	 */
+	public Body getBody1() {
+		return this.body1;
+	}
+
+	/**
+	 * Returns the second body.
+	 * @return Body
+	 * @since 3.3.1
+	 */
+	public Body getBody2() {
+		return this.body2;
+	}
+
+	/**
+	 * Returns the id of the fixture on the first body.
+	 * @return BodyFixture
+	 * @since 3.3.1
+	 */
+	public BodyFixture getFixture1() {
+		return this.fixture1;
+	}
+
+	/**
+	 * Returns the id of the fixture on the second body.
+	 * @return BodyFixture
+	 * @since 3.3.1
+	 */
+	public BodyFixture getFixture2() {
+		return this.fixture2;
 	}
 }

--- a/src/main/java/org/dyn4j/dynamics/contact/ContactConstraintId.java
+++ b/src/main/java/org/dyn4j/dynamics/contact/ContactConstraintId.java
@@ -173,7 +173,7 @@ public final class ContactConstraintId {
 	}
 
 	/**
-	 * Returns the id of the fixture on the first body.
+	 * Returns the fixture on the first body.
 	 * @return BodyFixture
 	 * @since 3.3.1
 	 */
@@ -182,7 +182,7 @@ public final class ContactConstraintId {
 	}
 
 	/**
-	 * Returns the id of the fixture on the second body.
+	 * Returns the fixture on the second body.
 	 * @return BodyFixture
 	 * @since 3.3.1
 	 */

--- a/src/main/java/org/dyn4j/dynamics/contact/ContactConstraintId.java
+++ b/src/main/java/org/dyn4j/dynamics/contact/ContactConstraintId.java
@@ -112,36 +112,44 @@ public final class ContactConstraintId {
 	
 	/**
 	 * Returns the id of the first body.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return UUID
 	 * @since 3.1.2
 	 */
+	@Deprecated(forRemoval = true)
 	public UUID getBody1Id() {
 		return this.body1.getId();
 	}
 
 	/**
 	 * Returns the id of the second body.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return UUID
 	 * @since 3.1.2
 	 */
+	@Deprecated(forRemoval = true)
 	public UUID getBody2Id() {
 		return this.body2.getId();
 	}
 
 	/**
 	 * Returns the id of the fixture on the first body.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return UUID
 	 * @since 3.1.2
 	 */
+	@Deprecated(forRemoval = true)
 	public UUID getFixture1Id() {
 		return this.fixture1.getId();
 	}
 
 	/**
 	 * Returns the id of the fixture on the second body.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return UUID
 	 * @since 3.1.2
 	 */
+	@Deprecated(forRemoval = true)
 	public UUID getFixture2Id() {
 		return this.fixture2.getId();
 	}

--- a/src/main/java/org/dyn4j/dynamics/joint/Joint.java
+++ b/src/main/java/org/dyn4j/dynamics/joint/Joint.java
@@ -141,9 +141,11 @@ public abstract class Joint extends Constraint implements Shiftable, DataContain
 	
 	/**
 	 * Returns the unique identifier for this joint instance.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return String
 	 * @since 3.0.1
 	 */
+	@Deprecated(forRemoval = true)
 	public UUID getId() {
 		return this.id;
 	}

--- a/src/main/java/org/dyn4j/geometry/AbstractShape.java
+++ b/src/main/java/org/dyn4j/geometry/AbstractShape.java
@@ -81,14 +81,6 @@ public abstract class AbstractShape implements Shape, Transformable, DataContain
 	}
 	
 	/* (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode() {
-		return this.id.hashCode();
-	}
-	
-	/* (non-Javadoc)
 	 * @see org.dyn4j.geometry.Shape#getId()
 	 */
 	@Override

--- a/src/main/java/org/dyn4j/geometry/AbstractShape.java
+++ b/src/main/java/org/dyn4j/geometry/AbstractShape.java
@@ -83,6 +83,7 @@ public abstract class AbstractShape implements Shape, Transformable, DataContain
 	/* (non-Javadoc)
 	 * @see org.dyn4j.geometry.Shape#getId()
 	 */
+	@Deprecated(forRemoval = true)
 	@Override
 	public UUID getId() {
 		return this.id;

--- a/src/main/java/org/dyn4j/geometry/Shape.java
+++ b/src/main/java/org/dyn4j/geometry/Shape.java
@@ -44,8 +44,10 @@ import org.dyn4j.DataContainer;
 public interface Shape extends Transformable, DataContainer {	
 	/**
 	 * Returns the unique identifier for this shape instance.
+	 * @deprecated ID schemes should be implemented by the user where needed
 	 * @return UUID
 	 */
+	@Deprecated(forRemoval = true)
 	public abstract UUID getId();
 	
 	/**

--- a/src/test/java/org/dyn4j/collision/FixtureTest.java
+++ b/src/test/java/org/dyn4j/collision/FixtureTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 /**
  * Test case for the {@link Fixture} class.
  * @author William Bittle
- * @version 3.1.1
+ * @version 3.3.1
  * @since 3.1.1
  */
 public class FixtureTest {
@@ -52,15 +52,6 @@ public class FixtureTest {
 	@Test(expected = NullPointerException.class)
 	public void createNullFixture() {
 		new Fixture(null);
-	}
-	
-	/**
-	 * Tests that an id is created for a fixture.
-	 */
-	@Test
-	public void getId() {
-		Fixture f = new Fixture(Geometry.createCircle(1.0));
-		TestCase.assertNotNull(f.getId());
 	}
 	
 	/**

--- a/src/test/java/org/dyn4j/dynamics/BodyTest.java
+++ b/src/test/java/org/dyn4j/dynamics/BodyTest.java
@@ -52,7 +52,7 @@ import org.junit.Test;
 /**
  * Class to test the {@link Body} class.
  * @author William Bittle
- * @version 3.1.8
+ * @version 3.3.1
  * @since 1.0.2
  */
 public class BodyTest {
@@ -64,7 +64,6 @@ public class BodyTest {
 		Body b = new Body();
 		
 		// these field should be defaulted
-		TestCase.assertNotNull(b.getId());
 		TestCase.assertNotNull(b.contacts);
 		TestCase.assertNotNull(b.getFixtures());
 		TestCase.assertNotNull(b.force);

--- a/src/test/java/org/dyn4j/geometry/AbstractShapeTest.java
+++ b/src/test/java/org/dyn4j/geometry/AbstractShapeTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 /**
  * Test case for the AbstractShape class.
  * @author William Bittle
- * @version 3.1.1
+ * @version 3.3.1
  * @since 3.1.1
  */
 public class AbstractShapeTest {
@@ -57,15 +57,6 @@ public class AbstractShapeTest {
 		public Interval project(Vector2 n, Transform transform) { return null; }
 	}
 	
-	/**
-	 * Tests that an id is created for a fixture.
-	 */
-	@Test
-	public void getId() {
-		Shape s = new TestShape();
-		TestCase.assertNotNull(s.getId());
-	}
-
 	/**
 	 * Make sure storage of user data is working.
 	 */


### PR DESCRIPTION
This pull request implements 'Part 1' of #47 (i.e. do not use IDs internally and deprecate the public API) with the ultimate goal of completely removing the use of IDs in the future.

There are two more open issues related to this that are not implemented (yet) in this PR:
- Consistent toString() use of IDs. I made some minor changes to attribute names in toString implementations but I have not replaced use of IDs yet. Consider the following implementation of ContactConstraintId#toString:
```java
sb.append("ContactConstraintId[Body1=").append(this.body1.getId())
		.append("|Body2=").append(this.body2.getId())
		.append("|Fixture1=").append(this.fixture1.getId())
		.append("|Fixture2=").append(this.fixture2.getId())
		.append("]");
```
If we remove getId() calls here the result will explode from ~4-5 lines of output to 20-50+ which is somewhat inconvenient (Similar for all places where IDs are printed as 'object links'). Also bodies that have their own id append it to the toString() result, which will have to be removed in the future as well.

My opinion is that we should replace all current uses of IDs in toString implementations with a new method similar to:
```java
public static String identityAlias(Object x) {
    return "@" + System.identityHashCode(x);
}
```
This retains -at some level- the printing of object IDs for convenience in the console/output while needs no extra field at those object, by exploiting the identity hashCode. This should be at some level familiar to the user, as it somewhat aligns with the default toString messages generated from the JVM.
- I believe we should somewhere make a 'migration guide' for users that previously used UUIDs in their code. Maybe it can be somewhere in the Javadoc or in some external source.
