### PR TITLE
Replace getId() with hashCode() for toString implementations

### DIFF
--- a/src/main/java/org/dyn4j/collision/broadphase/BroadphaseItem.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/BroadphaseItem.java
@@ -89,8 +89,8 @@ public final class BroadphaseItem<E extends Collidable<T>, T extends Fixture> {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("BroadphaseItem[Collidable=").append(this.collidable.getId())
-		.append("|Fixture=").append(this.fixture.getId())
+		sb.append("BroadphaseItem[Collidable=").append(this.collidable.hashCode())
+		.append("|Fixture=").append(this.fixture.hashCode())
 		.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/dyn4j/collision/broadphase/BroadphaseKey.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/BroadphaseKey.java
@@ -106,8 +106,8 @@ final class BroadphaseKey {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("BroadphaseKey[Collidable=").append(this.collidable.getId())
-		.append("|Fixture=").append(this.fixture.getId())
+		sb.append("BroadphaseKey[Collidable=").append(this.collidable.hashCode())
+		.append("|Fixture=").append(this.fixture.hashCode())
 		.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/dyn4j/collision/broadphase/BroadphasePair.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/BroadphasePair.java
@@ -106,10 +106,10 @@ public final class BroadphasePair<E extends Collidable<T>, T extends Fixture> {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("BroadphasePair[Collidable1=").append(this.collidable1.getId())
-		.append("|Fixture1=").append(this.fixture1.getId())
-		.append("|Collidable2=").append(this.collidable2.getId())
-		.append("|Fixture2=").append(this.fixture2.getId())
+		sb.append("BroadphasePair[Collidable1=").append(this.collidable1.hashCode())
+		.append("|Fixture1=").append(this.fixture1.hashCode())
+		.append("|Collidable2=").append(this.collidable2.hashCode())
+		.append("|Fixture2=").append(this.fixture2.hashCode())
 		.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/dyn4j/collision/broadphase/BruteForceBroadphaseNode.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/BruteForceBroadphaseNode.java
@@ -80,7 +80,7 @@ class BruteForceBroadphaseNode<E extends Collidable<T>, T extends Fixture> {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("PlainBroadphaseNode[AABB=").append(this.aabb.toString())
-		.append("|Fixture=").append(this.fixture.getId())
+		.append("|Fixture=").append(this.fixture.hashCode())
 		.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/dyn4j/collision/broadphase/DynamicAABBTreeLeaf.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/DynamicAABBTreeLeaf.java
@@ -91,8 +91,8 @@ final class DynamicAABBTreeLeaf<E extends Collidable<T>, T extends Fixture> exte
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("DynamicAABBTreeLeaf[Collidable=").append(this.collidable.getId())
-		  .append("|Fixture=").append(this.fixture.getId())
+		sb.append("DynamicAABBTreeLeaf[Collidable=").append(this.collidable.hashCode())
+		  .append("|Fixture=").append(this.fixture.hashCode())
 		  .append("|AABB=").append(this.aabb.toString())
 		  .append("|Height=").append(this.height)
 		  .append("|Tested=").append(this.tested)

--- a/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeLeaf.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/LazyAABBTreeLeaf.java
@@ -143,8 +143,8 @@ final class LazyAABBTreeLeaf<E extends Collidable<T>, T extends Fixture> extends
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("LazyAABBTreeLeaf[Collidable=").append(this.collidable.getId())
-		  .append("|Fixture=").append(this.fixture.getId())
+		sb.append("LazyAABBTreeLeaf[Collidable=").append(this.collidable.hashCode())
+		  .append("|Fixture=").append(this.fixture.hashCode())
 		  .append("|AABB=").append(this.aabb.toString())
 		  .append("|OnTree=").append(this.onTree)
 		  .append("]");

--- a/src/main/java/org/dyn4j/collision/broadphase/SapProxy.java
+++ b/src/main/java/org/dyn4j/collision/broadphase/SapProxy.java
@@ -114,8 +114,8 @@ final class SapProxy<E extends Collidable<T>, T extends Fixture> implements Comp
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("SapProxy[Collidable=").append(this.collidable != null ? this.collidable.getId() : "null")
-		  .append("|Fixture=").append(this.fixture != null ? this.fixture.getId() : "null")
+		sb.append("SapProxy[Collidable=").append(this.collidable != null ? this.collidable.hashCode() : "null")
+		  .append("|Fixture=").append(this.fixture != null ? this.fixture.hashCode() : "null")
 		  .append("|AABB=").append(this.aabb.toString())
 		  .append("|Tested=").append(this.tested)
 		  .append("]");

--- a/src/main/java/org/dyn4j/collision/narrowphase/MinkowskiSum.java
+++ b/src/main/java/org/dyn4j/collision/narrowphase/MinkowskiSum.java
@@ -72,9 +72,9 @@ public class MinkowskiSum {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("MinkowskiSum[Convex1=").append(this.convex1.getId())
+		sb.append("MinkowskiSum[Convex1=").append(this.convex1.hashCode())
 		.append("|Transform1=").append(this.transform1)
-		.append("|Convex2=").append(this.convex2.getId())
+		.append("|Convex2=").append(this.convex2.hashCode())
 		.append("|Transform2=").append(this.transform2)
 		.append("]");
 		return sb.toString();

--- a/src/main/java/org/dyn4j/dynamics/DetectResult.java
+++ b/src/main/java/org/dyn4j/dynamics/DetectResult.java
@@ -74,8 +74,8 @@ public class DetectResult {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("DetectResult[Body=").append(this.body.getId())
-		  .append("|Fixture=").append(this.fixture.getId())
+		sb.append("DetectResult[Body=").append(this.body.hashCode())
+		  .append("|Fixture=").append(this.fixture.hashCode())
 		  .append("|Penetration=").append(this.penetration)
 		  .append("]");
 		return sb.toString();

--- a/src/main/java/org/dyn4j/dynamics/contact/ContactConstraint.java
+++ b/src/main/java/org/dyn4j/dynamics/contact/ContactConstraint.java
@@ -140,10 +140,10 @@ public class ContactConstraint extends Constraint implements Shiftable {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("ContactConstraint[").append(super.toString())
-		  .append("|Body1=").append(this.body1.getId())
-		  .append("|Fixture1=").append(this.fixture1.getId())
-		  .append("|Body2=").append(this.body2.getId())
-		  .append("|Fixture2=").append(this.fixture2.getId())
+		  .append("|Body1=").append(this.body1.hashCode())
+		  .append("|Fixture1=").append(this.fixture1.hashCode())
+		  .append("|Body2=").append(this.body2.hashCode())
+		  .append("|Fixture2=").append(this.fixture2.hashCode())
 		  .append("|Normal=").append(this.normal)
 		  .append("|Tangent=").append(this.tangent)
 		  .append("|Friction=").append(this.friction)

--- a/src/main/java/org/dyn4j/dynamics/contact/ContactConstraintId.java
+++ b/src/main/java/org/dyn4j/dynamics/contact/ContactConstraintId.java
@@ -102,10 +102,10 @@ public final class ContactConstraintId {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("ContactConstraintId[Body1=").append(this.body1.getId())
-		.append("|Body2=").append(this.body2.getId())
-		.append("|Fixture1=").append(this.fixture1.getId())
-		.append("|Fixture2=").append(this.fixture2.getId())
+		sb.append("ContactConstraintId[Body1=").append(this.body1.hashCode())
+		.append("|Body2=").append(this.body2.hashCode())
+		.append("|Fixture1=").append(this.fixture1.hashCode())
+		.append("|Fixture2=").append(this.fixture2.hashCode())
 		.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/dyn4j/dynamics/contact/ContactPoint.java
+++ b/src/main/java/org/dyn4j/dynamics/contact/ContactPoint.java
@@ -131,10 +131,10 @@ public class ContactPoint {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("ContactPoint[Id=").append(this.id)
-		.append("|Body1=").append(this.body1.getId())
-		.append("|Fixture1=").append(this.fixture1.getId())
-		.append("|Body2=").append(this.body2.getId())
-		.append("|Fixture2=").append(this.fixture2.getId())
+		.append("|Body1=").append(this.body1.hashCode())
+		.append("|Fixture1=").append(this.fixture1.hashCode())
+		.append("|Body2=").append(this.body2.hashCode())
+		.append("|Fixture2=").append(this.fixture2.hashCode())
 		.append("|Point=").append(this.point)
 		.append("|Normal=").append(this.normal)
 		.append("|Depth=").append(this.depth)

--- a/src/main/java/org/dyn4j/dynamics/contact/PersistedContactPoint.java
+++ b/src/main/java/org/dyn4j/dynamics/contact/PersistedContactPoint.java
@@ -107,10 +107,10 @@ public class PersistedContactPoint extends ContactPoint {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("PersistedContactPoint[Id=").append(this.id)
-		  .append("|Body1=").append(this.body1.getId())
-		  .append("|Fixture1=").append(this.fixture1.getId())
-		  .append("|Body2=").append(this.body2.getId())
-		  .append("|Fixture2=").append(this.fixture2.getId())
+		  .append("|Body1=").append(this.body1.hashCode())
+		  .append("|Fixture1=").append(this.fixture1.hashCode())
+		  .append("|Body2=").append(this.body2.hashCode())
+		  .append("|Fixture2=").append(this.fixture2.hashCode())
 		  .append("|Point=").append(this.point)
 		  .append("|Normal=").append(this.normal)
 		  .append("|Depth=").append(this.depth)

--- a/src/main/java/org/dyn4j/dynamics/contact/SolvedContactPoint.java
+++ b/src/main/java/org/dyn4j/dynamics/contact/SolvedContactPoint.java
@@ -86,10 +86,10 @@ public class SolvedContactPoint extends ContactPoint {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("SolvedContactPoint[Id=").append(this.id)
-		  .append("|Body1=").append(this.body1.getId())
-		  .append("|Fixture1=").append(this.fixture1.getId())
-		  .append("|Body2=").append(this.body2.getId())
-		  .append("|Fixture2=").append(this.fixture2.getId())
+		  .append("|Body1=").append(this.body1.hashCode())
+		  .append("|Fixture1=").append(this.fixture1.hashCode())
+		  .append("|Body2=").append(this.body2.hashCode())
+		  .append("|Fixture2=").append(this.fixture2.hashCode())
 		  .append("|Point=").append(this.point)
 		  .append("|Normal=").append(this.normal)
 		  .append("|Depth=").append(this.depth)


### PR DESCRIPTION
Finish leftover from #77, use `hashCode` to implement links `toString` messages.