### PR TITLE
Automatically release maven staging artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
                 <configuration>
                 	<serverId>ossrh</serverId>
                 	<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                	<autoReleaseAfterClose>false</autoReleaseAfterClose>
+                	<autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Set autoReleaseAfterClose flag to true to allow for automatic drop out of staging when validation passes

Fixes #91 