### PR TITLE
Updated javadocs location to use javadoc.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ From here you should take a look at the [dyn4j-samples](https://github.com/dyn4j
 ### Links
 * [www.dyn4j.org](http://www.dyn4j.org)
 * [Latest Release Notes](https://github.com/dyn4j/dyn4j/blob/master/RELEASE-NOTES.md)
-* [Latest Javadocs](http://docs.dyn4j.org)
+* [Latest Javadocs](https://www.javadoc.io/doc/org.dyn4j/dyn4j/latest/index.html)
 * [Forum](http://forum.dyn4j.org) - disabled but still a good resource
 * [Blog](http://www.dyn4j.org/category/blog/)
 

--- a/overview.html
+++ b/overview.html
@@ -15,7 +15,7 @@
 	<ul>
 		<li>Downloads: <a href="http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.dyn4j%22%20AND%20a%3A%22dyn4j%22">Maven Central</a> or <a href="https://github.com/dyn4j/dyn4j/packages">GitHub Packages</a></li>
 		<li><a href="https://github.com/dyn4j/dyn4j/blob/master/RELEASE-NOTES.md">Release Notes</a></li>
-		<li>Javadocs: <a href="http://docs.dyn4j.org">http://docs.dyn4j.org</a></li>
+		<li>Javadocs: <a href="https://www.javadoc.io/doc/org.dyn4j/dyn4j/latest/index.html">https://www.javadoc.io/doc/org.dyn4j/dyn4j/latest/index.html</a></li>
 		<li>Issues: <a href="https://github.com/dyn4j/dyn4j/issues">https://github.com/dyn4j/dyn4j/issues</a></li>
 		<li>Source: <a href="https://github.com/dyn4j/dyn4j">https://github.com/dyn4j/dyn4j</a></li>
 	</ul>


### PR DESCRIPTION
Updated javadocs location to use javadoc.io in the overview.html and README.md