### PR TITLE
Fixed an issue where removing a body attached to a unary joint would throw a NullPointerException

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add dyn4j to your classpath by adding a Maven dependency from
 <dependency>
     <groupId>org.dyn4j</groupId>
     <artifactId>dyn4j</artifactId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
 </dependency>
 ```
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,13 @@
+## v4.1.3 - February 13th, 2021
+
+[Milestone](https://github.com/dyn4j/dyn4j/milestone/11?closed=1) |
+[Tag](https://github.com/dyn4j/dyn4j/tree/4.1.3) |
+[Maven Release](https://search.maven.org/artifact/org.dyn4j/dyn4j/4.1.3/bundle) |
+[GitHub Release](https://github.com/dyn4j/dyn4j/packages/93466?version=4.1.3)
+
+**Bug Fixes:**
+- [#181](https://github.com/dyn4j/dyn4j/issues/181) Fixed an issue when using the PinJoint and removing a body.
+
 ## v4.1.2 - February 9th, 2021
 
 [Milestone](https://github.com/dyn4j/dyn4j/milestone/10?closed=1) |

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.dyn4j</groupId>
   <artifactId>dyn4j</artifactId>
-  <version>4.1.2</version>
+  <version>4.1.3</version>
 
   <name>dyn4j</name>
   <url>http://www.dyn4j.org</url>

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Main-Class: org.dyn4j.Version
 Name: dyn4j
 Implementation-Title: Java Collision Detection and Physics Engine
-Implementation-Version: 4.1.2
+Implementation-Version: 4.1.3
 Implementation-Vendor: dyn4j.org

--- a/src/main/java/org/dyn4j/Version.java
+++ b/src/main/java/org/dyn4j/Version.java
@@ -27,7 +27,7 @@ package org.dyn4j;
 /**
  * The version of the engine.
  * @author William Bittle
- * @version 4.1.2
+ * @version 4.1.3
  * @since 1.0.0
  */
 public final class Version {
@@ -38,7 +38,7 @@ public final class Version {
 	private static final int MINOR = 1;
 	
 	/** The revision number; low impact changes; deprecating API changes, minor bug fixes, etc. */
-	private static final int REVISION = 2;
+	private static final int REVISION = 3;
 	
 	/**
 	 * Hide the constructor.

--- a/src/main/java/org/dyn4j/world/ConstraintGraph.java
+++ b/src/main/java/org/dyn4j/world/ConstraintGraph.java
@@ -53,7 +53,7 @@ import org.dyn4j.geometry.Vector2;
  * Solving of the graph happens internally by performing depth-first traversal and 
  * the building of {@link Island}s separated by static {@link PhysicsBody}s.
  * @author William Bittle
- * @version 4.1.2
+ * @version 4.1.3
  * @since 4.0.0
  * @param <T> the {@link PhysicsBody} type
  */
@@ -202,7 +202,11 @@ public final class ConstraintGraph<T extends PhysicsBody> {
 			T other = joint.getOtherBody(body);
 			// remove the joint edge from the other body
 			ConstraintGraphNode<T> otherNode = this.graph.get(other);
-			otherNode.joints.remove(joint);
+			// NOTE: some joints are unary and body1 == body2, and
+			// at this point, the body node has already been removed
+			if (otherNode != null) {
+				otherNode.joints.remove(joint);
+			}
 		}
 		
 		// remove any contact constraint edges

--- a/src/test/java/org/dyn4j/world/ConstraintGraphTest.java
+++ b/src/test/java/org/dyn4j/world/ConstraintGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 William Bittle  http://www.dyn4j.org/
+ * Copyright (c) 2010-2021 William Bittle  http://www.dyn4j.org/
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without modification, are permitted 
@@ -39,6 +39,7 @@ import org.dyn4j.dynamics.contact.SequentialImpulses;
 import org.dyn4j.dynamics.joint.AngleJoint;
 import org.dyn4j.dynamics.joint.DistanceJoint;
 import org.dyn4j.dynamics.joint.Joint;
+import org.dyn4j.dynamics.joint.PinJoint;
 import org.dyn4j.dynamics.joint.RevoluteJoint;
 import org.dyn4j.geometry.Convex;
 import org.dyn4j.geometry.Geometry;
@@ -51,7 +52,7 @@ import junit.framework.TestCase;
 /**
  * Tests the {@link ConstraintGraph} class.
  * @author William Bittle
- * @version 4.0.0
+ * @version 4.1.3
  * @since 4.0.0
  */
 public class ConstraintGraphTest {
@@ -1098,4 +1099,29 @@ public class ConstraintGraphTest {
 		
 		g.solve(solver, gravity, step, settings);
 	}
+
+	/**
+	 * Tests removing a body that's linked to a unary joint. In versions
+	 * 4.0.0 through 4.1.2 this would throw a NullPointerException.
+	 * @since 4.1.3
+	 */
+	@Test
+	public void testRemoveBodyWithUnaryJoint() {
+		ConstraintGraph<Body> g = new ConstraintGraph<Body>();
+		
+		Body b1 = new Body();
+		g.addBody(b1);
+		
+		Joint<Body> j1 = new PinJoint<Body>(b1, b1.getWorldCenter(), 8.0, 0.1, 1000);
+		g.addJoint(j1);
+		
+		TestCase.assertTrue(g.containsBody(b1));
+		TestCase.assertTrue(g.containsJoint(j1));
+		
+		g.removeBody(b1);
+		
+		TestCase.assertFalse(g.containsBody(b1));
+		TestCase.assertFalse(g.containsJoint(j1));
+	}
+	
 }


### PR DESCRIPTION
Found by my son while playing the BasketBall sample for the first time