### PR TITLE
Fix for sensor contact removal clearing the at rest state

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add dyn4j to your classpath by adding a Maven dependency from
 <dependency>
     <groupId>org.dyn4j</groupId>
     <artifactId>dyn4j</artifactId>
-    <version>4.1.3</version>
+    <version>4.1.4</version>
 </dependency>
 ```
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,13 @@
+## v4.1.4 - February 26th, 2021
+
+[Milestone](https://github.com/dyn4j/dyn4j/milestone/12?closed=1) |
+[Tag](https://github.com/dyn4j/dyn4j/tree/4.1.4) |
+[Maven Release](https://search.maven.org/artifact/org.dyn4j/dyn4j/4.1.4/bundle) |
+[GitHub Release](https://github.com/dyn4j/dyn4j/packages/93466?version=4.1.4)
+
+**Bug Fixes:**
+- [#186](https://github.com/dyn4j/dyn4j/issues/186) Fixed the removal of sensor fixtures so the atRest state of colliding bodies is unchanged
+
 ## v4.1.3 - February 13th, 2021
 
 [Milestone](https://github.com/dyn4j/dyn4j/milestone/11?closed=1) |

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.dyn4j</groupId>
   <artifactId>dyn4j</artifactId>
-  <version>4.1.3</version>
+  <version>4.1.4</version>
 
   <name>dyn4j</name>
   <url>http://www.dyn4j.org</url>

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Main-Class: org.dyn4j.Version
 Name: dyn4j
 Implementation-Title: Java Collision Detection and Physics Engine
-Implementation-Version: 4.1.3
+Implementation-Version: 4.1.4
 Implementation-Vendor: dyn4j.org

--- a/src/main/java/org/dyn4j/Version.java
+++ b/src/main/java/org/dyn4j/Version.java
@@ -27,7 +27,7 @@ package org.dyn4j;
 /**
  * The version of the engine.
  * @author William Bittle
- * @version 4.1.3
+ * @version 4.1.4
  * @since 1.0.0
  */
 public final class Version {
@@ -38,7 +38,7 @@ public final class Version {
 	private static final int MINOR = 1;
 	
 	/** The revision number; low impact changes; deprecating API changes, minor bug fixes, etc. */
-	private static final int REVISION = 3;
+	private static final int REVISION = 4;
 	
 	/**
 	 * Hide the constructor.

--- a/src/main/java/org/dyn4j/world/AbstractPhysicsWorld.java
+++ b/src/main/java/org/dyn4j/world/AbstractPhysicsWorld.java
@@ -89,7 +89,7 @@ import org.dyn4j.world.listener.TimeOfImpactListener;
  * more than one world. Likewise, the {@link Joint#setOwner(Object)} method is used to handle
  * joints being added to the world. Callers should <b>NOT</b> use the methods.
  * @author William Bittle
- * @version 4.1.1
+ * @version 4.1.4
  * @since 4.0.0
  * @param <T> the {@link PhysicsBody} type
  * @param <V> the {@link ContactCollisionData} type
@@ -520,9 +520,13 @@ public abstract class AbstractPhysicsWorld<T extends PhysicsBody, V extends Cont
 			}
 			
 			// get the other body involved
-			T other = contactConstraint.getOtherBody(body);				
-			// wake the other body
-			other.setAtRest(false);
+			T other = contactConstraint.getOtherBody(body);
+			
+			// clear the at-rest state of the connected body if the constraint
+			// is NOT a sensor and is enabled
+			if (!contactConstraint.isSensor() && contactConstraint.isEnabled()) {
+				other.setAtRest(false);
+			}
 			
 			// remove the stored collision data
 			V data = this.collisionData.remove(contactConstraint.getCollisionPair());

--- a/src/test/java/org/dyn4j/world/AbstractPhysicsWorldTest.java
+++ b/src/test/java/org/dyn4j/world/AbstractPhysicsWorldTest.java
@@ -2148,4 +2148,65 @@ public class AbstractPhysicsWorldTest {
 		
 		world.step(1);
 	}
+	
+	/**
+	 * Tests the scenario where a sensor fixture is removed and as such
+	 * triggers any sensor contact bodies to have their atRest flag reset.
+	 * @since 4.1.4
+	 */
+	@Test
+	public void sensorRemovalShouldNotClearAtRestState() {
+		TestWorld w = new TestWorld();
+		w.setGravity(0.0, 0.0);
+		
+		Body b1 = new Body();
+		BodyFixture bf = b1.addFixture(Geometry.createCircle(1.0));
+		bf.setSensor(true);
+		b1.translate(-0.5, 0.0);
+		b1.setMass(MassType.INFINITE);
+		w.addBody(b1);
+		
+		Body b2 = new Body();
+		b2.addFixture(Geometry.createCircle(1.0));
+		b2.translate(0.4, 0.0);
+		b2.setMass(MassType.NORMAL);
+		w.addBody(b2);
+		
+		w.step(10);
+		
+		b2.setAtRest(true);
+		TestCase.assertTrue(b2.isAtRest());
+		
+		b1.removeFixture(bf);
+		TestCase.assertTrue(b2.isAtRest());
+		
+		// now try the remove all method
+		
+		b1.addFixture(bf);
+		w.step(1);
+		b2.setAtRest(true);
+		TestCase.assertTrue(b2.isAtRest());
+		
+		b1.removeAllFixtures();
+		TestCase.assertTrue(b2.isAtRest());
+		
+		// try removal when the state of the contact is disabled
+		
+		bf.setSensor(false);
+		b1.addFixture(bf);
+		
+		w.addContactListener(new ContactListenerAdapter<Body>() {
+			@Override
+			public void collision(ContactCollisionData<Body> collision) {
+				collision.getContactConstraint().setEnabled(false);
+			}
+		});
+		
+		w.step(1);
+		b2.setAtRest(true);
+		TestCase.assertTrue(b2.isAtRest());
+		
+		b1.removeFixture(bf);
+		TestCase.assertTrue(b2.isAtRest());
+	}
 }


### PR DESCRIPTION
Fixed an issue where removing a sensor fixture would clear the at-rest state of any bodies the sensor fixture was colliding with.